### PR TITLE
feat: load characters from csv on web

### DIFF
--- a/anime-dataset/public/game.html
+++ b/anime-dataset/public/game.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Anime Character Guess</title>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <style>
     :root{
       --ok:#c8e6c9; --bad:#ffcdd2; --hint:#fff9c4;
@@ -709,8 +710,10 @@ function updateSummaryFromAll(){
       return Number.isFinite(n) && n > 0 ? n : null;
     }
     async function loadData(){
-      const resp = await fetch('/api/characters');
-      characters = await resp.json();
+      const resp = await fetch('../dataset/characters.csv');
+      const csvText = await resp.text();
+      const parsed = Papa.parse(csvText, { header: true });
+      characters = parsed.data.filter(c => c && c.character_id_mal);
 
       const topN = getTopParam();
       const sorted = [...characters].sort((a,b)=> malFav(b) - malFav(a));


### PR DESCRIPTION
## Summary
- load Papaparse from CDN to parse CSV
- fetch characters from dataset/characters.csv instead of API

## Testing
- `npm test --prefix anime-dataset` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7a0a9d4832fa52e20d087f83ca0