### PR TITLE
Initialize players with starting card and gray out disabled buttons

### DIFF
--- a/gameModeDigital.html
+++ b/gameModeDigital.html
@@ -44,6 +44,12 @@
       background: #14833b;
     }
 
+    button:disabled {
+      background: #555;
+      color: #888;
+      cursor: not-allowed;
+    }
+
 
     .controls {
       display: flex;
@@ -434,6 +440,16 @@
         coins: 2
       }));
       playlistTracks = await fetchPlaylistTracks(document.getElementById("playlistInput").value);
+      players.forEach(p => {
+        const track = randomTrack();
+        if (track) {
+          p.cards.push({
+            year: parseInt(track.year.slice(0,4)),
+            title: track.name,
+            artist: track.artist
+          });
+        }
+      });
       document.getElementById('setup').style.display = 'none';
       document.getElementById('gameArea').style.display = 'block';
       currentPlayerIndex = 0;


### PR DESCRIPTION
## Summary
- Give each player one starting card drawn from the pool and remove it from available tracks
- Add styling to gray out disabled buttons for clearer UI state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d23e0b20832fa3fb8f621cc1d484