### PR TITLE
Add arena dataset analyzer

### DIFF
--- a/arena-match-history.html
+++ b/arena-match-history.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <title>Arena Match Analyzer</title>
+  <style>
+    :root { --bg:#0b1020; --card:#131a2a; --muted:#8fa1c7; --text:#e9f0ff; --accent:#6aa9ff; --good:#56d364; }
+    body{margin:0;background:var(--bg);color:var(--text);font:16px/1.45 system-ui,Segoe UI,Roboto,Arial,sans-serif;padding-bottom:40px}
+    header{text-align:center;padding:28px 20px 10px;}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 16px}
+    form.tools{display:grid;gap:12px;grid-template-columns:1fr 1fr;align-items:end;margin:18px auto 14px;max-width:980px}
+    .field{display:flex;flex-direction:column;gap:6px}
+    label{font-size:13px;color:var(--muted)}
+    input,select,button{background:var(--card);border:1px solid #1e2a44;color:var(--text);padding:10px 12px;border-radius:10px;outline:none}
+    button{cursor:pointer;background:linear-gradient(180deg,#3b6dd8,#2c5ac0);border:0;box-shadow:0 6px 18px rgba(59,109,216,.25)}
+    .filehint{font-size:12px;color:#9ab0da}
+    table{width:100%;border-collapse:collapse;margin-top:20px}
+    th,td{padding:8px;border-bottom:1px solid #1e2a44;text-align:left;font-size:14px}
+    th{background:var(--card)}
+    .kvs{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:10px;margin:10px 0 18px}
+    .kv{background:var(--card);border:1px dashed #28406f;border-radius:12px;padding:10px 12px;font-size:13px}
+  </style>
+</head>
+<body>
+<header>
+  <h1>Arena Match Analyzer</h1>
+  <p class="sub">Importiere einen Datensatz aus Arena-Statistiken und analysiere deine Spiele.</p>
+</header>
+<div class="wrap">
+  <form class="tools">
+    <div class="field">
+      <label for="name">Beschwörername (optional)</label>
+      <input id="name" type="text" placeholder="z. B. Behamot" />
+    </div>
+    <div class="field">
+      <label>Datensatz</label>
+      <div class="row">
+        <input id="importFile" type="file" accept="application/json" style="display:none" />
+        <button id="importBtn" type="button">Importieren (.json)</button>
+      </div>
+      <div class="filehint" id="importInfo">Noch kein Datensatz importiert.</div>
+    </div>
+  </form>
+
+  <div class="kvs">
+    <div class="kv"><strong>KDA:</strong> <span id="kda">—</span></div>
+    <div class="kv"><strong>Beste Synergie:</strong> <span id="synergy">—</span></div>
+  </div>
+
+  <div>
+    <h2>Top Items</h2>
+    <ul id="items"></ul>
+  </div>
+
+  <div class="field" style="margin-top:20px">
+    <label for="filter">Champion-Filter</label>
+    <select id="filter"></select>
+  </div>
+
+  <table id="matchTable"></table>
+</div>
+
+<script>
+(() => {
+  const els = {
+    importBtn: document.getElementById('importBtn'),
+    importFile: document.getElementById('importFile'),
+    importInfo: document.getElementById('importInfo'),
+    name: document.getElementById('name'),
+    filter: document.getElementById('filter'),
+    matchTable: document.getElementById('matchTable'),
+    kda: document.getElementById('kda'),
+    synergy: document.getElementById('synergy'),
+    items: document.getElementById('items')
+  };
+  let dataset = null;
+  let matches = [];
+  let itemData = null;
+  const itemDataPromise = fetch('https://ddragon.leagueoflegends.com/cdn/14.17.1/data/en_US/item.json')
+    .then(r => r.json()).then(d => { itemData = d.data; });
+
+  els.importBtn.addEventListener('click', () => els.importFile.click());
+  els.importFile.addEventListener('change', async (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const obj = JSON.parse(text);
+      if (!obj || !Array.isArray(obj.matches) || !obj.puuid) throw new Error('Ungültiges Format');
+      dataset = obj;
+      els.importInfo.textContent = `Importiert: ${obj.player || 'Unbekannt'} • Matches: ${obj.count ?? obj.matches.length}`;
+      analyze();
+    } catch (err) {
+      console.error(err);
+      els.importInfo.textContent = 'Import fehlgeschlagen.';
+    } finally {
+      e.target.value = '';
+    }
+  });
+
+  function analyze() {
+    const puuid = dataset.puuid;
+    matches = dataset.matches.map(m => {
+      const ps = m.info.participants || [];
+      const me = ps.find(p => p.puuid === puuid);
+      if (!me) return null;
+      const teamId = me.playerSubteamId ?? me.subteamId;
+      const mates = ps.filter(p => p !== me && ((p.playerSubteamId ?? p.subteamId) === teamId));
+      const mate = mates[0];
+      const placement = me.subteamPlacement ?? me.placement;
+      const win = placement === 1 || me.win;
+      const items = [];
+      for (let i = 0; i <= 6; i++) {
+        const id = me['item' + i];
+        if (id) items.push(id);
+      }
+      return {
+        id: m.id,
+        champion: me.championName,
+        k: me.kills || 0,
+        d: me.deaths || 0,
+        a: me.assists || 0,
+        kda: ((me.kills || 0) + (me.assists || 0)) / Math.max(1, me.deaths || 0),
+        win,
+        items,
+        teammate: mate ? mate.championName : null
+      };
+    }).filter(Boolean);
+
+    const champs = Array.from(new Set(matches.map(m => m.champion))).sort();
+    els.filter.innerHTML = '<option value="">Alle Champions</option>' +
+      champs.map(c => `<option value="${c}">${c}</option>`).join('');
+    render();
+    renderStats();
+  }
+
+  els.filter.addEventListener('change', render);
+
+  async function render() {
+    await itemDataPromise;
+    const champ = els.filter.value;
+    const rows = matches.filter(m => !champ || m.champion === champ)
+      .map(m => {
+        const items = m.items.map(id => itemData[id]?.name || id).join(', ');
+        return `<tr><td>${m.champion}</td><td>${m.k}/${m.d}/${m.a} (${m.kda.toFixed(2)})</td><td>${m.win ? '✅' : '❌'}</td><td>${items}</td></tr>`;
+      }).join('');
+    els.matchTable.innerHTML = '<tr><th>Champion</th><th>K/D/A (KDA)</th><th>Win</th><th>Items</th></tr>' + rows;
+  }
+
+  async function renderStats() {
+    await itemDataPromise;
+    const sum = matches.reduce((acc, m) => { acc.k += m.k; acc.d += m.d; acc.a += m.a; return acc; }, { k: 0, d: 0, a: 0 });
+    const kda = (sum.k + sum.a) / Math.max(1, sum.d);
+    els.kda.textContent = `${sum.k}/${sum.d}/${sum.a} (${kda.toFixed(2)})`;
+
+    const sy = {};
+    for (const m of matches) {
+      if (!m.teammate) continue;
+      const obj = sy[m.teammate] || { games: 0, wins: 0 };
+      obj.games++;
+      if (m.win) obj.wins++;
+      sy[m.teammate] = obj;
+    }
+    let best = null;
+    for (const [champ, obj] of Object.entries(sy)) {
+      const wr = obj.wins / obj.games;
+      if (!best || wr > best.wr) best = { champ, wr, games: obj.games };
+    }
+    els.synergy.textContent = best ? `${best.champ} (${(best.wr * 100).toFixed(1)}% WR, ${best.games} Spiele)` : '—';
+
+    const items = {};
+    for (const m of matches) {
+      for (const id of m.items) {
+        const obj = items[id] || { games: 0, wins: 0 };
+        obj.games++;
+        if (m.win) obj.wins++;
+        items[id] = obj;
+      }
+    }
+    const top = Object.entries(items).sort((a, b) => b[1].games - a[1].games).slice(0, 5);
+    els.items.innerHTML = top.map(([id, obj]) => {
+      const wr = obj.wins / obj.games;
+      const name = itemData[id]?.name || id;
+      return `<li>${name}: ${(wr * 100).toFixed(1)}% WR (${obj.games})</li>`;
+    }).join('');
+  }
+})();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <a href="generator.html">Karten drucken</a>
     <a href="gameModeScan.html">Play Screen</a>
     <a href="gameModeDigital.html">Digital Mode</a>
+    <a href="arena-match-history.html">Arena Analyzer</a>
   </nav>
 
   <!-- Spotify Credentials Eingabe -->


### PR DESCRIPTION
## Summary
- add `arena-match-history.html` to inspect exported Arena datasets, compute KDA, teammate synergy, top items, and filter match history by champion
- link analyzer from index navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8167ccc58832fb6921efc363f3465