### PR TITLE
Split index into configuration page and dynamic subpages

### DIFF
--- a/config.html
+++ b/config.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="./styles.css">
+  <title>Konfiguration</title>
+</head>
+<body>
+  <h1>Konfiguration</h1>
+  <nav id="nav"></nav>
+  <div id="credentials">
+    <h2>Spotify Zugangsdaten</h2>
+    <label>
+      Client ID:
+      <input type="text" id="clientId" placeholder="Client ID">
+    </label>
+    <label>
+      Client Secret:
+      <input type="text" id="clientSecret" placeholder="Client Secret">
+    </label>
+    <label>
+      OpenAPI Token:
+      <input type="text" id="openApiToken" placeholder="Token">
+    </label>
+    <button onclick="saveCredentials()">Speichern</button>
+  </div>
+  <script src="pages.js"></script>
+  <script src="navigation.js"></script>
+  <script>
+    buildNavigation('nav');
+    document.getElementById('clientId').value = localStorage.getItem('CLIENT_ID') || '';
+    document.getElementById('clientSecret').value = localStorage.getItem('CLIENT_SECRET') || '';
+    document.getElementById('openApiToken').value = localStorage.getItem('OPENAPI_TOKEN') || '';
+    function saveCredentials() {
+      localStorage.setItem('CLIENT_ID', document.getElementById('clientId').value);
+      localStorage.setItem('CLIENT_SECRET', document.getElementById('clientSecret').value);
+      localStorage.setItem('OPENAPI_TOKEN', document.getElementById('openApiToken').value);
+      alert('Credentials gespeichert!');
+    }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,60 +1,16 @@
 <!DOCTYPE html>
 <html lang="de">
-
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="./styles.css">
-  </link>
   <title>Spotify Demo</title>
 </head>
-
 <body>
-
   <h1>Spotify Demo</h1>
-
-  <!-- Navigation -->
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="generator.html">Karten drucken</a>
-    <a href="gameModeScan.html">Play Screen</a>
-    <a href="gameModeDigital.html">Digital Mode</a>
-    <a href="arena-match-history.html">Arena Analyzer</a>
-  </nav>
-
-  <!-- Spotify Credentials Eingabe -->
-  <div id="credentials">
-    <h2>Spotify Zugangsdaten</h2>
-    <label>
-      Client ID:
-      <input type="text" id="clientId" placeholder="Client ID">
-    </label>
-    <label>
-      Client Secret:
-      <input type="text" id="clientSecret" placeholder="Client Secret">
-    </label>
-    <label>
-      OpenAPI Token:
-      <input type="text" id="openApiToken" placeholder="Token">
-    </label>
-    <button onclick="saveCredentials()">Speichern</button>
-  </div>
-
-  <script>
-    // vorhandene Credentials aus LocalStorage laden
-    document.getElementById("clientId").value = localStorage.getItem("CLIENT_ID") || "";
-    document.getElementById("clientSecret").value = localStorage.getItem("CLIENT_SECRET") || "";
-    document.getElementById("openApiToken").value = localStorage.getItem("OPENAPI_TOKEN") || "";
-
-    function saveCredentials() {
-      localStorage.setItem("CLIENT_ID", document.getElementById("clientId").value);
-      localStorage.setItem("CLIENT_SECRET", document.getElementById("clientSecret").value);
-      localStorage.setItem("OPENAPI_TOKEN", document.getElementById("openApiToken").value);
-      alert("Credentials gespeichert!");
-    }
-  </script>
-
-  <script src="spotify.js"></script>
+  <nav id="nav"></nav>
+  <script src="pages.js"></script>
+  <script src="navigation.js"></script>
+  <script>buildNavigation('nav');</script>
 </body>
-
 </html>

--- a/navigation.js
+++ b/navigation.js
@@ -1,0 +1,10 @@
+function buildNavigation(containerId) {
+  const nav = document.getElementById(containerId);
+  if (!nav || typeof pages === 'undefined') return;
+  pages.forEach(page => {
+    const a = document.createElement('a');
+    a.href = page.url;
+    a.textContent = page.title;
+    nav.appendChild(a);
+  });
+}

--- a/pages.js
+++ b/pages.js
@@ -1,0 +1,13 @@
+const pages = [
+  { title: 'Home', url: 'index.html' },
+  { title: 'Konfiguration', url: 'config.html' },
+  { title: 'Karten drucken', url: 'generator.html' },
+  { title: 'Play Screen', url: 'gameModeScan.html' },
+  { title: 'Digital Mode', url: 'gameModeDigital.html' },
+  { title: 'Arena Analyzer', url: 'arena-match-history.html' },
+  { title: 'Arena Stats', url: 'arena-stats.html' },
+  { title: 'Anidle', url: 'anidle.html' },
+  { title: 'Anidle Debug', url: 'anidleDebug.html' },
+  { title: 'Anime Charakterdle', url: 'animeCharakterdle.html' },
+  { title: 'Debug Log', url: 'debugLog.html' }
+];


### PR DESCRIPTION
## Summary
- Introduce `pages.js` configuration listing all site subpages
- Add `navigation.js` helper to render navigation dynamically
- Create new `config.html` for Spotify credentials
- Simplify `index.html` to build navigation from configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8259ba684832f9535a713be9b7fa7