### PR TITLE
Refine landing layout and navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,8 @@
 (() => {
   'use strict';
+  const searchParams = new URLSearchParams(window.location.search);
+  const SHOW_DEV_TOOLS = searchParams.has('dev') || searchParams.has('debug');
+
   const NAV_ITEMS = [
     { type: 'home', id: 'home', label: 'Übersicht' },
     {
@@ -80,8 +83,39 @@
     },
     {
       type: 'group',
-      id: 'anidle',
-      label: 'Anidle',
+      id: 'anime',
+      label: 'Anime Charakter',
+      items: [
+        {
+          type: 'page',
+          id: 'anime-riddle',
+          label: 'Rätsel Chat',
+          url: 'animeCharakterdle.html',
+          description: 'Errate Anime-Charaktere über das Chat-Interface mit KI-Unterstützung.'
+        },
+        {
+          type: 'page',
+          id: 'anime-dataset',
+          label: 'Dataset Verwaltung',
+          url: 'anime-dataset/public/index.html',
+          description: 'Pflege und erweitere den Charakter-Datensatz direkt im Browser.'
+        },
+        {
+          type: 'page',
+          id: 'anime-dataset-game',
+          label: 'Dataset Guess Game',
+          url: 'anime-dataset/public/game.html',
+          description: 'Nutze den Datensatz für eine schnelle Ratesession ohne Chat.'
+        }
+      ]
+    }
+  ];
+
+  if (SHOW_DEV_TOOLS) {
+    NAV_ITEMS.push({
+      type: 'group',
+      id: 'dev',
+      label: 'Dev',
       items: [
         {
           type: 'page',
@@ -96,20 +130,13 @@
           label: 'Anidle Debug',
           url: 'anidleDebug.html',
           description: 'Debug-Ansicht mit tieferen Einsichten in Anidle-Läufe.'
-        }
-      ]
-    },
-    {
-      type: 'group',
-      id: 'experiments',
-      label: 'Experimente & Tools',
-      items: [
+        },
         {
           type: 'page',
-          id: 'animeCharakterdle',
-          label: 'Anime Charakterdle',
-          url: 'animeCharakterdle.html',
-          description: 'Errate Anime-Charaktere mit OpenAI-Unterstützung und eigenem Datensatz.'
+          id: 'legacy-config',
+          label: 'Standalone Konfiguration',
+          url: 'config.html',
+          description: 'Separate Konfigurationsoberfläche aus einer frühen Toolkit-Version.'
         },
         {
           type: 'page',
@@ -119,6 +146,17 @@
           description: 'Zeige gespeicherte Debug-Informationen direkt im Browser an.'
         }
       ]
+    });
+  }
+
+  const EXTERNAL_LINKS = [
+    {
+      id: 'contact',
+      label: 'Kontakt',
+      url: 'https://github.com/Behamot007/Behamot007.github.io/discussions',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      title: 'Feedback & Verbesserungen auf GitHub diskutieren'
     }
   ];
 
@@ -158,7 +196,7 @@
         name: 'OpenAI Platform',
         url: 'https://platform.openai.com/account/api-keys'
       },
-      usage: ['Anime Charakterdle', 'AI-Experimente'],
+      usage: ['Anime Charakter Rätsel', 'Anime Dataset Tools'],
       fields: [
         {
           id: 'openai-token',
@@ -178,7 +216,7 @@
         name: 'Riot Developer Portal',
         url: 'https://developer.riotgames.com/'
       },
-      usage: ['Arena Stats'],
+      usage: ['Arena Stats', 'Arena Match Analyzer'],
       fields: [
         {
           id: 'riot-api',
@@ -221,6 +259,8 @@
         createGroup(item);
       }
     });
+
+    EXTERNAL_LINKS.forEach(link => createExternalLink(link));
   }
 
   function createHomeButton(item) {
@@ -271,6 +311,22 @@
     wrapper.append(toggle, dropdown);
     navContainer.appendChild(wrapper);
     groupElements.set(group.id, { container: wrapper, toggle, dropdown, data: group });
+  }
+
+  function createExternalLink(link) {
+    const anchor = document.createElement('a');
+    anchor.className = 'nav-button nav-button--link';
+    anchor.href = link.url;
+    anchor.textContent = link.label;
+    anchor.target = link.target || '_blank';
+    anchor.rel = link.rel || 'noopener noreferrer';
+    if (link.title) {
+      anchor.title = link.title;
+      anchor.setAttribute('aria-label', link.title);
+    } else {
+      anchor.setAttribute('aria-label', link.label);
+    }
+    navContainer.appendChild(anchor);
   }
 
   function toggleGroup(id) {

--- a/index.css
+++ b/index.css
@@ -78,11 +78,11 @@ a:focus-visible {
 }
 
 .site-header {
-  padding: clamp(1rem, 2vw, 1.75rem) clamp(1.25rem, 4vw, 2.75rem);
+  padding: clamp(0.75rem, 1.6vw, 1.25rem) clamp(1rem, 3.5vw, 2.25rem);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1.25rem;
+  gap: 1rem;
   background: linear-gradient(120deg, rgba(16, 28, 52, 0.85), rgba(8, 15, 32, 0.9));
   border-bottom: 1px solid rgba(116, 142, 201, 0.25);
   box-shadow: 0 20px 40px -30px rgba(5, 10, 20, 0.8);
@@ -101,12 +101,12 @@ a:focus-visible {
 
 .brand__title {
   font-weight: 700;
-  font-size: clamp(1.35rem, 3vw, 1.8rem);
+  font-size: clamp(1.25rem, 2.6vw, 1.65rem);
   color: var(--text-strong);
 }
 
 .brand__subtitle {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
   color: var(--muted);
 }
 
@@ -115,19 +115,24 @@ a:focus-visible {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.45rem;
   justify-content: flex-end;
 }
 
 .nav-button,
 .nav-group__toggle {
-  padding: 0.55rem 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1rem;
   border-radius: 999px;
   background: rgba(18, 30, 55, 0.8);
   border: 1px solid transparent;
   color: var(--text);
   font-weight: 600;
   letter-spacing: 0.01em;
+  font-size: 0.95rem;
+  line-height: 1.2;
   transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
@@ -264,7 +269,7 @@ a:focus-visible {
   background: linear-gradient(135deg, rgba(144, 103, 249, 0.35), rgba(78, 205, 196, 0.15));
   border: 1px solid rgba(144, 103, 249, 0.45);
   border-radius: 1.5rem;
-  padding: clamp(1.4rem, 4vw, 2.75rem);
+  padding: clamp(1.25rem, 3.5vw, 2.35rem);
   box-shadow: var(--shadow-lg);
   margin-bottom: clamp(1.75rem, 4vw, 2.8rem);
   overflow: hidden;
@@ -285,8 +290,23 @@ a:focus-visible {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.9rem;
   max-width: 620px;
+}
+
+.hero-card__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .hero-card__body h1 {
@@ -303,8 +323,8 @@ a:focus-visible {
 .hero-card__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.8rem;
-  margin-top: 0.5rem;
+  gap: 0.65rem;
+  margin-top: 0.35rem;
 }
 
 .button {
@@ -312,7 +332,7 @@ a:focus-visible {
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  padding: 0.6rem 1.4rem;
+  padding: 0.52rem 1.2rem;
   border-radius: 999px;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -362,7 +382,7 @@ a:focus-visible {
   flex-direction: column;
   gap: 0.9rem;
   box-shadow: var(--shadow-md);
-  min-height: 220px;
+  min-height: 210px;
 }
 
 .home-card h2 {
@@ -377,6 +397,18 @@ a:focus-visible {
   flex: 1 1 auto;
 }
 
+.home-card__badge {
+  align-self: flex-start;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .home-card__links {
   display: flex;
   flex-wrap: wrap;
@@ -387,7 +419,7 @@ a:focus-visible {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.45rem 0.95rem;
+  padding: 0.4rem 0.85rem;
   border-radius: 0.85rem;
   background: rgba(78, 205, 196, 0.12);
   border: 1px solid rgba(78, 205, 196, 0.22);
@@ -594,10 +626,7 @@ a:focus-visible {
 }
 
 .site-footer {
-  min-height: 70px;
-  padding: 1.5rem clamp(1.25rem, 5vw, 3.5rem);
-  border-top: 1px solid rgba(116, 142, 201, 0.25);
-  background: rgba(8, 14, 28, 0.7);
+  display: none;
 }
 
 @media (max-width: 960px) {

--- a/index.html
+++ b/index.html
@@ -20,33 +20,28 @@
         <section id="homeView" class="view view--active" aria-labelledby="homeTitle">
           <div class="hero-card">
             <div class="hero-card__body">
-              <h1 id="homeTitle">Alles an einem Ort</h1>
+              <span class="hero-card__eyebrow">Arena Stats jetzt mit Schnellzugriff</span>
+              <h1 id="homeTitle">Arena-Analysen im Rampenlicht</h1>
               <p>
-                Verwalte deine benötigten API-Zugänge und starte die passenden Tools direkt hier auf der
-                Startseite. Keine neuen Tabs mehr &ndash; der Inhalt wird im Arbeitsbereich eingebettet.
+                Starte deine Auswertung mit nur einem Klick in den eingebetteten Arena Stats und verwalte bei
+                Bedarf direkt hier deine notwendigen Konfigurationen.
               </p>
               <div class="hero-card__actions">
-                <button type="button" class="button button--accent" data-nav-target="config-overview">
-                  Zu den Konfigurationen
+                <button type="button" class="button button--accent" data-nav-target="arena-stats">
+                  Arena Stats starten
                 </button>
-                <button type="button" class="button button--ghost" data-nav-target="arena-stats">
-                  Arena Stats öffnen
+                <button type="button" class="button button--ghost" data-nav-target="config-overview">
+                  Konfigurationen verwalten
                 </button>
               </div>
             </div>
           </div>
 
           <div class="home-grid" aria-label="Projektbereiche">
-            <article class="home-card">
-              <h2>Konfigurationen</h2>
-              <p>API-Schlüssel und Tokens zentral speichern. Die Tools greifen automatisch darauf zu.</p>
-              <button type="button" class="link-button" data-nav-target="config-overview">
-                Übersicht anzeigen
-              </button>
-            </article>
-            <article class="home-card">
-              <h2>Arena</h2>
-              <p>Analysiere Matches mit der Riot API oder nutze importierte Datensätze im Analyzer.</p>
+            <article class="home-card home-card--arena">
+              <div class="home-card__badge">Arena Stats im Fokus</div>
+              <h2>Arena Insights</h2>
+              <p>Nutze aktuelle Riot-Daten und importierte Matches, um Trends und Strategien aufzudecken.</p>
               <div class="home-card__links">
                 <button type="button" class="link-button" data-nav-target="arena-stats">Arena Stats</button>
                 <button type="button" class="link-button" data-nav-target="arena-analyzer">Match Analyzer</button>
@@ -59,6 +54,29 @@
                 <button type="button" class="link-button" data-nav-target="generator">QR Karten</button>
                 <button type="button" class="link-button" data-nav-target="play-screen">Play Screen</button>
                 <button type="button" class="link-button" data-nav-target="digital-mode">Digital Mode</button>
+              </div>
+            </article>
+            <article class="home-card home-card--anime">
+              <h2>Anime Charakter Rätsel</h2>
+              <p>Teste dein Wissen mit dem Rätsel-Chat oder pflege den zugrunde liegenden Charakter-Datensatz.</p>
+              <div class="home-card__links">
+                <button type="button" class="link-button" data-nav-target="anime-riddle">Rätsel Chat</button>
+                <button type="button" class="link-button" data-nav-target="anime-dataset">Dataset Verwaltung</button>
+                <button type="button" class="link-button" data-nav-target="anime-dataset-game">Dataset Guess Game</button>
+              </div>
+            </article>
+            <article class="home-card home-card--contact">
+              <h2>Kontakt &amp; Feedback</h2>
+              <p>Diskutiere Ideen, Wünsche und Verbesserungen direkt in den GitHub Discussions.</p>
+              <div class="home-card__links">
+                <a
+                  class="link-button"
+                  href="https://github.com/Behamot007/Behamot007.github.io/discussions"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Zu GitHub Discussions
+                </a>
               </div>
             </article>
           </div>
@@ -95,7 +113,7 @@
         </section>
       </main>
 
-      <footer class="site-footer" aria-label="Seitenende"></footer>
+      <footer class="site-footer" aria-label="Seitenende" hidden></footer>
     </div>
 
     <script src="app.js"></script>

--- a/navigation.js
+++ b/navigation.js
@@ -5,6 +5,10 @@ function buildNavigation(containerId) {
     const a = document.createElement('a');
     a.href = page.url;
     a.textContent = page.title;
+    if (/^https?:/i.test(page.url)) {
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+    }
     nav.appendChild(a);
   });
 }

--- a/pages.js
+++ b/pages.js
@@ -1,13 +1,16 @@
 const pages = [
   { title: 'Home', url: 'index.html' },
-  { title: 'Konfiguration', url: 'config.html' },
-  { title: 'Karten drucken', url: 'generator.html' },
+  { title: 'Konfiguration (Standalone)', url: 'config.html' },
+  { title: 'Arena Stats', url: 'arena-stats.html' },
+  { title: 'Arena Match Analyzer', url: 'arena-match-history.html' },
+  { title: 'Playlist → QR Cards', url: 'generator.html' },
   { title: 'Play Screen', url: 'gameModeScan.html' },
   { title: 'Digital Mode', url: 'gameModeDigital.html' },
-  { title: 'Arena Analyzer', url: 'arena-match-history.html' },
-  { title: 'Arena Stats', url: 'arena-stats.html' },
   { title: 'Anidle', url: 'anidle.html' },
   { title: 'Anidle Debug', url: 'anidleDebug.html' },
-  { title: 'Anime Charakterdle', url: 'animeCharakterdle.html' },
-  { title: 'Debug Log', url: 'debugLog.html' }
+  { title: 'Anime Rätsel Chat', url: 'animeCharakterdle.html' },
+  { title: 'Anime Dataset Verwaltung', url: 'anime-dataset/public/index.html' },
+  { title: 'Anime Dataset Guess Game', url: 'anime-dataset/public/game.html' },
+  { title: 'Debug Log', url: 'debugLog.html' },
+  { title: 'Kontakt (GitHub)', url: 'https://github.com/Behamot007/Behamot007.github.io/discussions' }
 ];


### PR DESCRIPTION
## Summary
- compact the landing header and hero, highlight Arena Stats, remove the duplicate Konfiguration card, and add dedicated Anime Rätsel and Kontakt widgets
- reduce button styling footprint and hide the footer for a leaner layout
- reorganise navigation with an Anime group, a parameter-gated Dev section, dataset links, and a GitHub contact shortcut while keeping the legacy page list in sync

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c847523234832f9e109746fa753c12