### PR TITLE
Add shared cost calculator with experimental receipt analysis

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,6 +83,20 @@
     },
     {
       type: 'group',
+      id: 'everyday',
+      label: 'Alltag & Planung',
+      items: [
+        {
+          type: 'page',
+          id: 'bill-splitter',
+          label: 'Kostenkalkulation',
+          url: 'bill-splitter.html',
+          description: 'Berechne faire Anteile für gemeinsame Rechnungen und Freunde.'
+        }
+      ]
+    },
+    {
+      type: 'group',
       id: 'anime',
       label: 'Anime Charakter',
       items: [

--- a/bill-splitter.css
+++ b/bill-splitter.css
@@ -1,0 +1,618 @@
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(130% 110% at 15% 15%, #13233d 0%, #071021 55%, #030814 100%);
+  --surface: rgba(14, 24, 42, 0.9);
+  --surface-strong: rgba(16, 28, 48, 0.95);
+  --surface-border: rgba(88, 118, 175, 0.35);
+  --surface-border-strong: rgba(88, 118, 175, 0.55);
+  --text: #f4f7ff;
+  --text-strong: #ffffff;
+  --muted: #92a2cb;
+  --muted-strong: #b6c5eb;
+  --primary: #4ecdc4;
+  --primary-strong: #2fb5a9;
+  --primary-soft: rgba(78, 205, 196, 0.14);
+  --secondary: #7c83ff;
+  --secondary-soft: rgba(124, 131, 255, 0.18);
+  --danger: #ff6f59;
+  --warning: #f6c453;
+  --success: #4ade80;
+  --chip-bg: rgba(32, 51, 82, 0.6);
+  --shadow-lg: 0 32px 65px -45px rgba(7, 12, 24, 0.9);
+  --shadow-md: 0 22px 45px -36px rgba(7, 12, 24, 0.85);
+  --shadow-sm: 0 10px 30px -25px rgba(7, 12, 24, 0.8);
+  --font-family: 'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-family);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: var(--primary);
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+p {
+  margin: 0;
+}
+
+button {
+  font: inherit;
+  border: none;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid rgba(78, 205, 196, 0.6);
+  outline-offset: 3px;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem) clamp(1.5rem, 5vw, 3.5rem) clamp(1rem, 3.5vw, 2rem);
+}
+
+.page-header__text {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.page-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted-strong);
+}
+
+.page-content {
+  flex: 1 1 auto;
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  padding: 0 clamp(1.25rem, 4vw, 3rem) clamp(2.5rem, 6vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.page-content > .card.card--summary,
+.page-content > .card.card--experimental {
+  grid-column: 1 / -1;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 1.5rem;
+  padding: clamp(1.35rem, 3vw, 2rem);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.card__subtitle {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.card__note {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.form-inline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.85rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  flex: 1 1 auto;
+}
+
+.form-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted-strong);
+  letter-spacing: 0.02em;
+}
+
+input[type='text'],
+input[type='number'],
+input[type='search'],
+textarea {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(120, 150, 210, 0.4);
+  background: rgba(11, 18, 32, 0.75);
+  color: var(--text);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+input[type='text']:focus,
+input[type='number']:focus,
+textarea:focus {
+  border-color: rgba(78, 205, 196, 0.65);
+  background: rgba(13, 22, 38, 0.92);
+}
+
+.form-fieldset {
+  margin: 0;
+  border: 1px dashed rgba(94, 120, 180, 0.45);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-fieldset legend {
+  padding: 0 0.35rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted-strong);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, var(--primary), var(--primary-strong));
+  color: #062520;
+  box-shadow: var(--shadow-sm);
+}
+
+.button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px -28px rgba(78, 205, 196, 0.8);
+}
+
+.button--secondary {
+  background: rgba(124, 131, 255, 0.15);
+  color: var(--secondary);
+  border-color: rgba(124, 131, 255, 0.35);
+}
+
+.button--secondary:hover {
+  background: rgba(124, 131, 255, 0.22);
+}
+
+.button--ghost {
+  border: 1px solid rgba(78, 205, 196, 0.45);
+  background: transparent;
+  color: var(--primary);
+}
+
+.button--ghost:hover {
+  background: rgba(78, 205, 196, 0.12);
+}
+
+.form-feedback {
+  min-height: 1.2rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.form-feedback[data-type='success'] {
+  color: var(--success);
+}
+
+.form-feedback[data-type='error'] {
+  color: var(--danger);
+}
+
+.form-feedback[data-type='warning'] {
+  color: var(--warning);
+}
+
+.person-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.person-chip {
+  --chip-color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.45rem 0.75rem 0.45rem 0.55rem;
+  border-radius: 999px;
+  background: var(--chip-bg);
+  border: 1px solid rgba(82, 110, 170, 0.45);
+  box-shadow: var(--shadow-sm);
+}
+
+.person-chip__avatar {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.05)), var(--chip-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #04121a;
+  text-transform: uppercase;
+}
+
+.person-chip__name {
+  font-weight: 600;
+}
+
+.person-chip__remove {
+  background: rgba(5, 12, 24, 0.45);
+  color: var(--muted);
+  border-radius: 50%;
+  width: 1.8rem;
+  height: 1.8rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.person-chip__remove:hover {
+  color: var(--danger);
+}
+
+.participant-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.person-checkbox {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(17, 30, 52, 0.8);
+  border: 1px solid rgba(88, 118, 175, 0.45);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.person-checkbox:hover {
+  border-color: rgba(78, 205, 196, 0.55);
+}
+
+.person-checkbox__input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.person-checkbox__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.person-checkbox__input:checked + .person-checkbox__label,
+.person-checkbox__input:focus-visible + .person-checkbox__label {
+  color: var(--primary);
+}
+
+.participant-selector__empty {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.expense-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.expense-card {
+  background: var(--surface-strong);
+  border-radius: 1.3rem;
+  border: 1px solid var(--surface-border-strong);
+  padding: 1.1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.expense-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.expense-card__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.expense-card__amount {
+  color: var(--muted-strong);
+  font-size: 0.95rem;
+}
+
+.expense-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.expense-card__hint {
+  font-size: 0.85rem;
+  color: var(--warning);
+}
+
+.expense-card__share {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.tag-toggle {
+  --tag-color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(78, 205, 196, 0.35);
+  background: rgba(11, 22, 38, 0.75);
+  color: var(--muted-strong);
+  font-weight: 600;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.tag-toggle--active {
+  background: var(--tag-color);
+  color: #04121a;
+  border-color: rgba(4, 18, 26, 0.2);
+  box-shadow: 0 14px 30px -24px rgba(78, 205, 196, 0.8);
+}
+
+.summary-table-wrapper {
+  overflow-x: auto;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(78, 205, 196, 0.18);
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.summary-table thead {
+  background: rgba(10, 24, 38, 0.85);
+  border-bottom: 1px solid rgba(78, 205, 196, 0.25);
+}
+
+.summary-table tbody tr:nth-child(odd) {
+  background: rgba(10, 22, 36, 0.55);
+}
+
+.summary-breakdown {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.summary-breakdown details {
+  background: rgba(12, 23, 40, 0.7);
+  border: 1px solid rgba(78, 205, 196, 0.18);
+  border-radius: 0.85rem;
+  padding: 0.6rem 0.8rem;
+}
+
+.summary-breakdown summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--muted-strong);
+}
+
+.summary-breakdown ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.summary-totals {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+}
+
+.summary-total {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.summary-total--accent {
+  color: var(--primary);
+}
+
+.summary-note {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.summary-unassigned {
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 159, 89, 0.1);
+  color: #ffba7a;
+  border: 1px solid rgba(255, 159, 89, 0.35);
+}
+
+.empty-state {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 600;
+}
+
+.badge--experimental {
+  background: rgba(255, 159, 89, 0.16);
+  color: #ffb169;
+  border: 1px solid rgba(255, 159, 89, 0.35);
+}
+
+.experimental-upload {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.file-input {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 1px dashed rgba(124, 131, 255, 0.4);
+  background: rgba(20, 28, 50, 0.9);
+  padding: 0.85rem 1.2rem;
+  cursor: pointer;
+  min-width: 240px;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.file-input:hover {
+  border-color: rgba(124, 131, 255, 0.65);
+}
+
+.file-input__label {
+  font-weight: 600;
+  color: var(--secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.file-input input[type='file'] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .page-content {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .page-header {
+    padding: 1.25rem 1.25rem 1rem;
+  }
+
+  .form-inline {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .experimental-upload {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/bill-splitter.html
+++ b/bill-splitter.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kostenaufteilung für gemeinsame Rechnungen</title>
+    <link rel="stylesheet" href="bill-splitter.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="page-header">
+        <div class="page-header__text">
+          <p class="page-eyebrow">Gemeinsam rechnen, fair teilen</p>
+          <h1>Gemeinsame Kostenkalkulation</h1>
+          <p>
+            Erfasse Ausgaben, tagge die beteiligten Personen und erhalte automatisch aufgerundete
+            Beträge, damit jede Person ihren fairen Anteil bezahlt.
+          </p>
+        </div>
+        <div class="header-actions">
+          <a class="button button--ghost" href="index.html">Zurück zur Toolkit-Übersicht</a>
+        </div>
+      </header>
+
+      <main class="page-content">
+        <section class="card" aria-labelledby="peopleTitle">
+          <div class="card__header">
+            <h2 id="peopleTitle">Teilnehmende Personen</h2>
+            <p class="card__subtitle">
+              Vergib Namen für alle Personen, die sich die Rechnung teilen. Die Farben helfen dir bei der
+              Zuordnung in den Ausgaben.
+            </p>
+          </div>
+          <form id="personForm" class="form-inline" autocomplete="off">
+            <label class="form-field" for="personName">
+              <span class="form-label">Name</span>
+              <input id="personName" name="personName" type="text" required placeholder="z. B. Alex" />
+            </label>
+            <button type="submit" class="button button--primary">Person hinzufügen</button>
+          </form>
+          <p id="personFeedback" class="form-feedback" role="status" aria-live="polite"></p>
+          <div
+            id="personList"
+            class="person-list"
+            role="list"
+            aria-live="polite"
+            aria-label="Aktive Personen"
+          ></div>
+        </section>
+
+        <section class="card" aria-labelledby="expensesTitle">
+          <div class="card__header">
+            <h2 id="expensesTitle">Einzelausgaben erfassen</h2>
+            <p class="card__subtitle">
+              Jede Ausgabe kann mehreren Personen zugeordnet werden. Du kannst die Zuordnung auch nach dem
+              Speichern über die farbigen Tags anpassen.
+            </p>
+          </div>
+          <form id="expenseForm" class="stacked-form" autocomplete="off">
+            <div class="form-grid">
+              <label class="form-field" for="expenseName">
+                <span class="form-label">Beschreibung</span>
+                <input
+                  id="expenseName"
+                  name="expenseName"
+                  type="text"
+                  placeholder="z. B. Pizza Margherita"
+                  required
+                />
+              </label>
+              <label class="form-field" for="expenseAmount">
+                <span class="form-label">Betrag in €</span>
+                <input
+                  id="expenseAmount"
+                  name="expenseAmount"
+                  type="text"
+                  inputmode="decimal"
+                  pattern="[0-9]+([,\.]?[0-9]{0,4})?"
+                  placeholder="0,00"
+                  required
+                />
+              </label>
+            </div>
+            <fieldset class="form-fieldset">
+              <legend>Personen-Tagging</legend>
+              <div id="expenseParticipants" class="participant-selector"></div>
+            </fieldset>
+            <div class="form-actions">
+              <button type="submit" class="button button--primary">Ausgabe speichern</button>
+              <button type="button" id="expenseResetBtn" class="button button--secondary">Zurücksetzen</button>
+            </div>
+          </form>
+          <p id="expenseFeedback" class="form-feedback" role="status" aria-live="polite"></p>
+          <div
+            id="expenseList"
+            class="expense-list"
+            role="list"
+            aria-live="polite"
+            aria-label="Erfasste Ausgaben"
+          ></div>
+        </section>
+
+        <section class="card card--summary" aria-labelledby="summaryTitle">
+          <div class="card__header">
+            <h2 id="summaryTitle">Kostenübersicht pro Person</h2>
+            <p class="card__subtitle">
+              Zwischenwerte werden mit allen Nachkommastellen berechnet. Endbeträge werden auf zwei
+              Nachkommastellen <strong>aufgerundet</strong>, damit keine Person zu wenig zahlt.
+            </p>
+          </div>
+          <div id="summaryEmpty" class="empty-state">
+            Füge Personen und Ausgaben hinzu, um die Aufteilung zu berechnen.
+          </div>
+          <div id="summaryTableWrapper" class="summary-table-wrapper" hidden>
+            <table class="summary-table">
+              <thead>
+                <tr>
+                  <th scope="col">Person</th>
+                  <th scope="col">Zwischensumme</th>
+                  <th scope="col">Aufgerundet</th>
+                  <th scope="col">Aufschlag</th>
+                </tr>
+              </thead>
+              <tbody id="summaryBody"></tbody>
+            </table>
+          </div>
+          <div id="personBreakdown" class="summary-breakdown"></div>
+          <div id="summaryTotals" class="summary-totals" hidden>
+            <div class="summary-total"><span>Gesamtausgaben:</span> <strong id="totalsActual"></strong></div>
+            <div class="summary-total"><span>Summe aufgerundet:</span> <strong id="totalsRounded"></strong></div>
+            <div class="summary-total summary-total--accent">
+              <span>Aufrundungsreserve:</span> <strong id="roundingDifference"></strong>
+            </div>
+            <p id="roundingNote" class="summary-note"></p>
+          </div>
+          <p id="unassignedInfo" class="summary-unassigned" hidden></p>
+        </section>
+
+        <section
+          id="experimentalSection"
+          class="card card--experimental"
+          aria-labelledby="experimentalTitle"
+          hidden
+        >
+          <div class="card__header">
+            <div>
+              <span class="badge badge--experimental">Experimentell</span>
+              <h2 id="experimentalTitle">Kassenbon per KI vorbefüllen</h2>
+              <p class="card__subtitle">
+                Aktiviere das Feature über den URL-Parameter <code>?receiptAI</code> oder
+                <code>&amp;receiptAI</code>. Dein hinterlegtes OpenAI-Token wird für die Analyse verwendet.
+              </p>
+            </div>
+          </div>
+          <p>
+            Lade ein Foto deines Kassenbons hoch oder mache direkt über die Kamera eines Geräts ein Bild.
+            Die KI versucht, die Positionen zu erkennen und schlägt passende Zuordnungen zu den vorhandenen
+            Personen vor.
+          </p>
+          <div class="experimental-upload">
+            <label class="file-input">
+              <span class="file-input__label">Foto aufnehmen oder wählen</span>
+              <input type="file" id="receiptInput" accept="image/*" capture="environment" />
+            </label>
+            <button type="button" id="analyzeReceiptBtn" class="button button--primary" disabled>
+              Ausgaben übernehmen
+            </button>
+          </div>
+          <p class="card__note">
+            Hinweis: Das ausgewählte Bild wird zur Analyse an die OpenAI API gesendet. Überprüfe die
+            Ergebnisse vor dem Speichern.
+          </p>
+          <p id="experimentalStatus" class="form-feedback" role="status" aria-live="polite"></p>
+        </section>
+      </main>
+    </div>
+
+    <script src="ai.js"></script>
+    <script src="bill-splitter.js"></script>
+  </body>
+</html>

--- a/bill-splitter.js
+++ b/bill-splitter.js
@@ -1,0 +1,789 @@
+(() => {
+  'use strict';
+
+  const state = {
+    persons: [],
+    expenses: [],
+  };
+
+  const PERSON_COLORS = [
+    '#4ecdc4',
+    '#ff9f6e',
+    '#7c83ff',
+    '#f6c453',
+    '#9b5de5',
+    '#00bbf0',
+    '#ff6f91',
+    '#6ee7b7',
+    '#f97316',
+    '#5eead4',
+  ];
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const showExperimental = searchParams.has('receiptAI');
+
+  const personForm = document.getElementById('personForm');
+  const personNameInput = document.getElementById('personName');
+  const personFeedbackEl = document.getElementById('personFeedback');
+  const personListEl = document.getElementById('personList');
+
+  const expenseForm = document.getElementById('expenseForm');
+  const expenseNameInput = document.getElementById('expenseName');
+  const expenseAmountInput = document.getElementById('expenseAmount');
+  const expenseParticipantsEl = document.getElementById('expenseParticipants');
+  const expenseFeedbackEl = document.getElementById('expenseFeedback');
+  const expenseListEl = document.getElementById('expenseList');
+  const expenseResetBtn = document.getElementById('expenseResetBtn');
+
+  const summaryEmptyEl = document.getElementById('summaryEmpty');
+  const summaryTableWrapperEl = document.getElementById('summaryTableWrapper');
+  const summaryBodyEl = document.getElementById('summaryBody');
+  const personBreakdownEl = document.getElementById('personBreakdown');
+  const summaryTotalsEl = document.getElementById('summaryTotals');
+  const totalsActualEl = document.getElementById('totalsActual');
+  const totalsRoundedEl = document.getElementById('totalsRounded');
+  const roundingDifferenceEl = document.getElementById('roundingDifference');
+  const roundingNoteEl = document.getElementById('roundingNote');
+  const unassignedInfoEl = document.getElementById('unassignedInfo');
+
+  const experimentalSection = document.getElementById('experimentalSection');
+  const receiptInput = document.getElementById('receiptInput');
+  const analyzeReceiptBtn = document.getElementById('analyzeReceiptBtn');
+  const experimentalStatusEl = document.getElementById('experimentalStatus');
+
+  const currencyFormatter = new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: 'EUR',
+  });
+
+  const preciseFormatter = new Intl.NumberFormat('de-DE', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  });
+
+  const DEFAULT_EXPERIMENTAL_HINT =
+    'Füge Personen hinzu, damit Vorschläge zur Zuordnung gemacht werden können.';
+
+  let receiptFile = null;
+  let isAnalyzing = false;
+
+  if (experimentalSection) {
+    experimentalSection.hidden = !showExperimental;
+  }
+
+  function generateId() {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function getInitials(name) {
+    return name
+      .trim()
+      .split(/\s+/)
+      .map(part => part[0] || '')
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
+  }
+
+  function assignColor(index) {
+    return PERSON_COLORS[index % PERSON_COLORS.length];
+  }
+
+  function setFeedback(element, message, type = 'info') {
+    if (!element) return;
+    element.textContent = message || '';
+    if (message) {
+      element.dataset.type = type;
+    } else {
+      delete element.dataset.type;
+    }
+  }
+
+  function normalizeAmountInput(value) {
+    if (typeof value !== 'string') return '';
+    return value.trim().replace(/\s+/g, '').replace(',', '.');
+  }
+
+  function parseEuroToCents(value) {
+    const normalized = normalizeAmountInput(value);
+    if (!normalized) {
+      return null;
+    }
+    const amount = Number(normalized);
+    if (!Number.isFinite(amount) || amount < 0) {
+      return null;
+    }
+    return Math.round(amount * 100);
+  }
+
+  function centsToEuro(cents) {
+    return cents / 100;
+  }
+
+  function roundUpToCents(value) {
+    return Math.ceil(value * 100 - 1e-9) / 100;
+  }
+
+  function roundToCents(value) {
+    return Math.round((value + Number.EPSILON) * 100);
+  }
+
+  function formatCurrency(value) {
+    return currencyFormatter.format(value);
+  }
+
+  function formatPreciseEuro(value) {
+    return `${preciseFormatter.format(value)} €`;
+  }
+
+  function updateAnalyzeButtonState() {
+    if (!analyzeReceiptBtn) return;
+    analyzeReceiptBtn.disabled = !showExperimental || !receiptFile || state.persons.length === 0 || isAnalyzing;
+  }
+
+  function updateExperimentalDefaultMessage() {
+    if (!showExperimental || !experimentalStatusEl) return;
+    if (state.persons.length === 0) {
+      if (
+        !experimentalStatusEl.textContent ||
+        experimentalStatusEl.textContent === DEFAULT_EXPERIMENTAL_HINT
+      ) {
+        setFeedback(experimentalStatusEl, DEFAULT_EXPERIMENTAL_HINT, 'info');
+      }
+    } else if (experimentalStatusEl.textContent === DEFAULT_EXPERIMENTAL_HINT) {
+      setFeedback(experimentalStatusEl, '', 'info');
+    }
+  }
+
+  function addPerson(name) {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setFeedback(personFeedbackEl, 'Bitte einen Namen eingeben.', 'error');
+      return;
+    }
+
+    if (trimmed.length > 40) {
+      setFeedback(personFeedbackEl, 'Bitte einen kürzeren Namen wählen.', 'error');
+      return;
+    }
+
+    const exists = state.persons.some(person => person.name.toLowerCase() === trimmed.toLowerCase());
+    if (exists) {
+      setFeedback(personFeedbackEl, `${trimmed} ist bereits vorhanden.`, 'warning');
+      return;
+    }
+
+    const person = {
+      id: generateId(),
+      name: trimmed,
+      color: assignColor(state.persons.length),
+    };
+
+    state.persons.push(person);
+    setFeedback(personFeedbackEl, `${person.name} hinzugefügt.`, 'success');
+    personNameInput.value = '';
+    personNameInput.focus();
+    renderPersons();
+    renderParticipantSelector();
+    renderExpenses();
+    renderSummary();
+    updateAnalyzeButtonState();
+    if (showExperimental && experimentalStatusEl) {
+      if (experimentalStatusEl.textContent === DEFAULT_EXPERIMENTAL_HINT) {
+        setFeedback(experimentalStatusEl, '', 'info');
+      }
+    }
+    updateExperimentalDefaultMessage();
+  }
+
+  function removePerson(personId) {
+    const index = state.persons.findIndex(person => person.id === personId);
+    if (index === -1) return;
+    const [removed] = state.persons.splice(index, 1);
+    state.expenses.forEach(expense => expense.participantIds.delete(personId));
+    setFeedback(personFeedbackEl, `${removed.name} entfernt.`, 'info');
+    renderPersons();
+    renderParticipantSelector();
+    renderExpenses();
+    renderSummary();
+    updateAnalyzeButtonState();
+    updateExperimentalDefaultMessage();
+  }
+
+  function addExpense(form) {
+    if (state.persons.length === 0) {
+      setFeedback(expenseFeedbackEl, 'Lege zuerst Personen an.', 'error');
+      return;
+    }
+
+    const name = expenseNameInput.value.trim();
+    const amountCents = parseEuroToCents(expenseAmountInput.value);
+    const formData = new FormData(form);
+    const participants = new Set(formData.getAll('participants'));
+
+    if (!name) {
+      setFeedback(expenseFeedbackEl, 'Bitte eine Beschreibung angeben.', 'error');
+      return;
+    }
+
+    if (amountCents === null || amountCents === undefined) {
+      setFeedback(expenseFeedbackEl, 'Bitte einen gültigen Betrag eingeben.', 'error');
+      return;
+    }
+
+    if (amountCents === 0) {
+      setFeedback(expenseFeedbackEl, 'Der Betrag muss größer als 0 sein.', 'error');
+      return;
+    }
+
+    const expense = {
+      id: generateId(),
+      label: name,
+      amountCents,
+      participantIds: participants,
+    };
+
+    state.expenses.push(expense);
+    form.reset();
+    setFeedback(expenseFeedbackEl, `Ausgabe „${name}” gespeichert.`, 'success');
+    renderExpenses();
+    renderSummary();
+    updateAnalyzeButtonState();
+  }
+
+  function removeExpense(expenseId) {
+    const index = state.expenses.findIndex(expense => expense.id === expenseId);
+    if (index === -1) return;
+    const [removed] = state.expenses.splice(index, 1);
+    setFeedback(expenseFeedbackEl, `Ausgabe „${removed.label}” entfernt.`, 'info');
+    renderExpenses();
+    renderSummary();
+    updateAnalyzeButtonState();
+  }
+
+  function toggleExpenseParticipant(expenseId, personId) {
+    const expense = state.expenses.find(item => item.id === expenseId);
+    if (!expense) return;
+    if (expense.participantIds.has(personId)) {
+      expense.participantIds.delete(personId);
+    } else {
+      expense.participantIds.add(personId);
+    }
+    renderExpenses();
+    renderSummary();
+    updateAnalyzeButtonState();
+  }
+
+  function renderPersons() {
+    if (!personListEl) return;
+    personListEl.innerHTML = '';
+
+    if (state.persons.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-state';
+      empty.textContent = 'Noch keine Personen hinzugefügt.';
+      personListEl.appendChild(empty);
+      return;
+    }
+
+    state.persons.forEach(person => {
+      const item = document.createElement('div');
+      item.className = 'person-chip';
+      item.setAttribute('role', 'listitem');
+      item.style.setProperty('--chip-color', person.color);
+
+      const avatar = document.createElement('span');
+      avatar.className = 'person-chip__avatar';
+      avatar.textContent = getInitials(person.name);
+
+      const name = document.createElement('span');
+      name.className = 'person-chip__name';
+      name.textContent = person.name;
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'person-chip__remove';
+      removeBtn.dataset.removePerson = person.id;
+      removeBtn.setAttribute('aria-label', `${person.name} entfernen`);
+      removeBtn.innerHTML = '<span aria-hidden="true">×</span>';
+
+      item.append(avatar, name, removeBtn);
+      personListEl.appendChild(item);
+    });
+  }
+
+  function renderParticipantSelector() {
+    if (!expenseParticipantsEl) return;
+    expenseParticipantsEl.innerHTML = '';
+
+    if (state.persons.length === 0) {
+      const note = document.createElement('p');
+      note.className = 'participant-selector__empty';
+      note.textContent = 'Lege zuerst Personen an, um Ausgaben zuzuordnen.';
+      expenseParticipantsEl.appendChild(note);
+      return;
+    }
+
+    state.persons.forEach(person => {
+      const label = document.createElement('label');
+      label.className = 'person-checkbox';
+      label.style.setProperty('--chip-color', person.color);
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.className = 'person-checkbox__input';
+      input.name = 'participants';
+      input.value = person.id;
+
+      const text = document.createElement('span');
+      text.className = 'person-checkbox__label';
+      text.textContent = person.name;
+
+      label.append(input, text);
+      expenseParticipantsEl.appendChild(label);
+    });
+  }
+
+  function renderExpenses() {
+    if (!expenseListEl) return;
+    expenseListEl.innerHTML = '';
+
+    if (state.expenses.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-state';
+      empty.textContent = 'Noch keine Ausgaben erfasst.';
+      expenseListEl.appendChild(empty);
+      return;
+    }
+
+    state.expenses.forEach(expense => {
+      const card = document.createElement('article');
+      card.className = 'expense-card';
+      card.setAttribute('role', 'listitem');
+      card.dataset.expenseId = expense.id;
+
+      const header = document.createElement('div');
+      header.className = 'expense-card__header';
+
+      const titleWrap = document.createElement('div');
+      titleWrap.className = 'expense-card__meta';
+
+      const title = document.createElement('h3');
+      title.className = 'expense-card__title';
+      title.textContent = expense.label;
+
+      const amount = document.createElement('span');
+      amount.className = 'expense-card__amount';
+      amount.textContent = formatCurrency(centsToEuro(expense.amountCents));
+
+      titleWrap.append(title, amount);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'button button--secondary';
+      removeBtn.dataset.removeExpense = expense.id;
+      removeBtn.textContent = 'Entfernen';
+
+      header.append(titleWrap, removeBtn);
+
+      const tags = document.createElement('div');
+      tags.className = 'expense-card__tags';
+
+      state.persons.forEach(person => {
+        const toggle = document.createElement('button');
+        toggle.type = 'button';
+        toggle.className = 'tag-toggle';
+        toggle.dataset.personId = person.id;
+        toggle.dataset.expenseId = expense.id;
+        toggle.textContent = person.name;
+        toggle.style.setProperty('--tag-color', person.color);
+        if (expense.participantIds.has(person.id)) {
+          toggle.classList.add('tag-toggle--active');
+        }
+        tags.appendChild(toggle);
+      });
+
+      const fragments = [header, tags];
+
+      if (expense.participantIds.size === 0) {
+        const hint = document.createElement('p');
+        hint.className = 'expense-card__hint';
+        hint.textContent = 'Noch keiner Person zugeordnet.';
+        fragments.push(hint);
+      } else {
+        const shareEuro = centsToEuro(expense.amountCents / expense.participantIds.size);
+        const share = document.createElement('p');
+        share.className = 'expense-card__share';
+        share.textContent = `Zwischenanteil pro Person: ${formatPreciseEuro(shareEuro)}`;
+        fragments.push(share);
+      }
+
+      fragments.forEach(fragment => card.appendChild(fragment));
+      expenseListEl.appendChild(card);
+    });
+  }
+
+  function calculateTotals() {
+    const perPerson = state.persons.map(person => ({
+      person,
+      rawShare: 0,
+      contributions: [],
+    }));
+
+    const perPersonMap = new Map(perPerson.map(entry => [entry.person.id, entry]));
+
+    let totalExpenseCents = 0;
+    let assignedExpenseCents = 0;
+
+    state.expenses.forEach(expense => {
+      totalExpenseCents += expense.amountCents;
+      const participantCount = expense.participantIds.size;
+      if (participantCount === 0) {
+        return;
+      }
+      assignedExpenseCents += expense.amountCents;
+      const shareEuro = centsToEuro(expense.amountCents / participantCount);
+      expense.participantIds.forEach(personId => {
+        const entry = perPersonMap.get(personId);
+        if (!entry) return;
+        entry.rawShare += shareEuro;
+        entry.contributions.push({
+          expenseLabel: expense.label,
+          shareEuro,
+          participantCount,
+          totalEuro: centsToEuro(expense.amountCents),
+        });
+      });
+    });
+
+    perPerson.forEach(entry => {
+      entry.roundedShare = roundUpToCents(entry.rawShare);
+      entry.roundingDifference = entry.roundedShare - entry.rawShare;
+    });
+
+    const totalRoundedCents = perPerson.reduce((sum, entry) => sum + roundToCents(entry.roundedShare), 0);
+    const totalRoundedEuro = centsToEuro(totalRoundedCents);
+    const totalExpensesEuro = centsToEuro(totalExpenseCents);
+    const roundingReserve = totalRoundedEuro - totalExpensesEuro;
+    const unassignedEuro = centsToEuro(totalExpenseCents - assignedExpenseCents);
+
+    return {
+      perPerson,
+      totals: {
+        totalExpensesEuro,
+        totalRoundedEuro,
+        roundingReserve,
+        unassignedEuro,
+      },
+    };
+  }
+
+  function renderSummary() {
+    if (!summaryBodyEl || !summaryEmptyEl || !summaryTableWrapperEl) return;
+
+    if (state.persons.length === 0 || state.expenses.length === 0) {
+      summaryEmptyEl.hidden = false;
+      summaryTableWrapperEl.hidden = true;
+      summaryTotalsEl && (summaryTotalsEl.hidden = true);
+      personBreakdownEl && (personBreakdownEl.innerHTML = '');
+      if (unassignedInfoEl) {
+        unassignedInfoEl.hidden = true;
+      }
+      return;
+    }
+
+    const { perPerson, totals } = calculateTotals();
+
+    summaryEmptyEl.hidden = true;
+    summaryTableWrapperEl.hidden = false;
+
+    summaryBodyEl.innerHTML = '';
+    perPerson.forEach(entry => {
+      const row = document.createElement('tr');
+
+      const nameCell = document.createElement('th');
+      nameCell.scope = 'row';
+      nameCell.textContent = entry.person.name;
+      nameCell.style.setProperty('color', entry.person.color);
+
+      const rawCell = document.createElement('td');
+      rawCell.textContent = formatPreciseEuro(entry.rawShare);
+
+      const roundedCell = document.createElement('td');
+      roundedCell.textContent = formatCurrency(entry.roundedShare);
+
+      const diffCell = document.createElement('td');
+      const diff = entry.roundingDifference;
+      if (diff > 0) {
+        diffCell.textContent = `+${formatCurrency(diff)}`;
+      } else if (diff < 0) {
+        diffCell.textContent = `-${formatCurrency(Math.abs(diff))}`;
+      } else {
+        diffCell.textContent = formatCurrency(0);
+      }
+
+      row.append(nameCell, rawCell, roundedCell, diffCell);
+      summaryBodyEl.appendChild(row);
+    });
+
+    if (summaryTotalsEl && totalsActualEl && totalsRoundedEl && roundingDifferenceEl && roundingNoteEl) {
+      summaryTotalsEl.hidden = false;
+      totalsActualEl.textContent = formatCurrency(totals.totalExpensesEuro);
+      totalsRoundedEl.textContent = formatCurrency(totals.totalRoundedEuro);
+
+      const normalizedReserve = Math.abs(totals.roundingReserve) < 1e-8 ? 0 : totals.roundingReserve;
+      if (normalizedReserve > 0) {
+        roundingDifferenceEl.textContent = `+${formatCurrency(normalizedReserve)}`;
+      } else if (normalizedReserve < 0) {
+        roundingDifferenceEl.textContent = `-${formatCurrency(Math.abs(normalizedReserve))}`;
+      } else {
+        roundingDifferenceEl.textContent = formatCurrency(0);
+      }
+
+      if (normalizedReserve > 0) {
+        roundingDifferenceEl.parentElement?.classList.add('summary-total--accent');
+        roundingNoteEl.textContent =
+          'Durch das Aufrunden entsteht eine kleine Reserve. Sie stellt sicher, dass niemand zu wenig zahlt.';
+      } else if (normalizedReserve < 0) {
+        roundingDifferenceEl.parentElement?.classList.add('summary-total--accent');
+        roundingNoteEl.textContent =
+          'Achtung: Die aufgerundeten Beträge liegen unter den tatsächlichen Kosten. Prüfe die Zuordnungen erneut.';
+      } else {
+        roundingDifferenceEl.parentElement?.classList.remove('summary-total--accent');
+        roundingNoteEl.textContent = 'Die gerundeten Beiträge entsprechen exakt der Summe der Ausgaben.';
+      }
+    }
+
+    if (personBreakdownEl) {
+      personBreakdownEl.innerHTML = '';
+      perPerson.forEach(entry => {
+        const details = document.createElement('details');
+        details.open = false;
+
+        const summary = document.createElement('summary');
+        summary.textContent = `Anteile von ${entry.person.name}`;
+        summary.style.setProperty('color', entry.person.color);
+
+        details.appendChild(summary);
+
+        const list = document.createElement('ul');
+        if (entry.contributions.length === 0) {
+          const item = document.createElement('li');
+          item.textContent = 'Keine Ausgaben zugeordnet.';
+          list.appendChild(item);
+        } else {
+          entry.contributions.forEach(contribution => {
+            const item = document.createElement('li');
+            item.textContent = `${contribution.expenseLabel}: ${formatPreciseEuro(
+              contribution.shareEuro
+            )} aus ${formatCurrency(contribution.totalEuro)} (${contribution.participantCount} Personen)`;
+            list.appendChild(item);
+          });
+        }
+
+        details.appendChild(list);
+        personBreakdownEl.appendChild(details);
+      });
+    }
+
+    if (unassignedInfoEl) {
+      if (totals.unassignedEuro > 0) {
+        unassignedInfoEl.hidden = false;
+        unassignedInfoEl.textContent = `Noch nicht zugeordnete Ausgaben: ${formatCurrency(
+          totals.unassignedEuro
+        )}. Diese Kosten werden aktuell niemandem berechnet.`;
+      } else {
+        unassignedInfoEl.hidden = true;
+        unassignedInfoEl.textContent = '';
+      }
+    }
+  }
+
+  async function fileToBase64(file) {
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = String(reader.result || '');
+        const parts = result.split(',');
+        resolve(parts.length > 1 ? parts[1] : result);
+      };
+      reader.onerror = () => reject(new Error('Bild konnte nicht gelesen werden.'));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  async function requestExpensePrefill(base64Image, mimeType) {
+    if (typeof callAI !== 'function') {
+      throw new Error('Die KI-Schnittstelle ist nicht verfügbar.');
+    }
+
+    const personNames = state.persons.map(person => person.name).join(', ') || 'keine Personen';
+
+    const systemPrompt = `Du extrahierst Positionen aus fotografierten Kassenbons. Gib ausschließlich valides JSON zurück.
+Schema:
+{
+  "expenses": [
+    {
+      "title": "Artikelname",
+      "amount": 0.00,
+      "suggested_participants": ["Name"]
+    }
+  ]
+}
+Regeln:
+- "amount" ist der Preis pro Position in Euro mit Punkt als Dezimaltrennzeichen.
+- Gib maximal 20 Positionen zurück.
+- Verwende nur Namen aus der Personenliste für "suggested_participants". Wenn keine Zuordnung möglich ist, gib ein leeres Array zurück.
+- Ignoriere Gesamt- oder Wechselgeld-Zeilen.`;
+
+    const userPrompt = `Personenliste: ${personNames}.
+Analysiere den folgenden Kassenbon (${mimeType}). Der Inhalt ist Base64-kodiert:
+${base64Image}
+
+Liefere das JSON gemäß Schema.`;
+
+    return await callAI({
+      systemPrompt,
+      userPrompt,
+      model: 'gpt-4o-mini',
+      temperature: 0.2,
+      maxTokens: 900,
+      retries: 2,
+    });
+  }
+
+  function applyPrefill(data) {
+    if (!data || typeof data !== 'object' || !Array.isArray(data.expenses)) {
+      throw new Error('Unerwartetes KI-Ergebnis.');
+    }
+
+    let added = 0;
+    data.expenses.forEach(entry => {
+      if (!entry || typeof entry !== 'object') return;
+      const title = String(entry.title || entry.name || '').trim();
+      const amountNumber = Number(entry.amount);
+      if (!title || !Number.isFinite(amountNumber) || amountNumber <= 0) return;
+
+      const amountCents = Math.round(amountNumber * 100);
+      const suggested = Array.isArray(entry.suggested_participants) ? entry.suggested_participants : [];
+      const participants = new Set();
+      suggested.forEach(label => {
+        const person = state.persons.find(p => p.name.toLowerCase() === String(label).trim().toLowerCase());
+        if (person) {
+          participants.add(person.id);
+        }
+      });
+
+      state.expenses.push({
+        id: generateId(),
+        label: title,
+        amountCents,
+        participantIds: participants,
+      });
+      added += 1;
+    });
+
+    if (added === 0) {
+      throw new Error('Es konnten keine passenden Positionen erkannt werden.');
+    }
+
+    renderExpenses();
+    renderSummary();
+    updateAnalyzeButtonState();
+  }
+
+  async function handleAnalyzeReceipt() {
+    if (!receiptFile) return;
+    if (state.persons.length === 0) {
+      setFeedback(
+        experimentalStatusEl,
+        'Bitte lege zunächst Personen an, damit Zuordnungen vorgeschlagen werden können.',
+        'error'
+      );
+      return;
+    }
+
+    isAnalyzing = true;
+    updateAnalyzeButtonState();
+    setFeedback(experimentalStatusEl, 'Analysiere Kassenbon …', 'info');
+
+    try {
+      const base64 = await fileToBase64(receiptFile);
+      const result = await requestExpensePrefill(base64, receiptFile.type || 'unbekannt');
+      applyPrefill(result);
+      setFeedback(
+        experimentalStatusEl,
+        'Die Vorschläge wurden übernommen. Bitte prüfe die Ausgaben und passe sie bei Bedarf an.',
+        'success'
+      );
+    } catch (error) {
+      setFeedback(experimentalStatusEl, error.message || 'Analyse fehlgeschlagen.', 'error');
+      console.error(error);
+    } finally {
+      isAnalyzing = false;
+      updateAnalyzeButtonState();
+    }
+  }
+
+  personForm?.addEventListener('submit', event => {
+    event.preventDefault();
+    addPerson(personNameInput.value);
+  });
+
+  personListEl?.addEventListener('click', event => {
+    const button = event.target.closest('[data-remove-person]');
+    if (!button) return;
+    removePerson(button.dataset.removePerson || '');
+  });
+
+  expenseForm?.addEventListener('submit', event => {
+    event.preventDefault();
+    addExpense(expenseForm);
+  });
+
+  expenseResetBtn?.addEventListener('click', () => {
+    expenseForm?.reset();
+    setFeedback(expenseFeedbackEl, '', 'info');
+  });
+
+  expenseListEl?.addEventListener('click', event => {
+    const removeBtn = event.target.closest('[data-remove-expense]');
+    if (removeBtn) {
+      removeExpense(removeBtn.dataset.removeExpense || '');
+      return;
+    }
+    const toggle = event.target.closest('.tag-toggle');
+    if (toggle) {
+      toggleExpenseParticipant(toggle.dataset.expenseId || '', toggle.dataset.personId || '');
+    }
+  });
+
+  receiptInput?.addEventListener('change', event => {
+    const input = event.target;
+    if (!input || !input.files) return;
+    receiptFile = input.files[0] || null;
+    if (receiptFile) {
+      setFeedback(experimentalStatusEl, `${receiptFile.name} ausgewählt.`, 'info');
+    } else {
+      setFeedback(experimentalStatusEl, '', 'info');
+    }
+    updateAnalyzeButtonState();
+    updateExperimentalDefaultMessage();
+  });
+
+  analyzeReceiptBtn?.addEventListener('click', () => {
+    if (!isAnalyzing) {
+      handleAnalyzeReceipt();
+    }
+  });
+
+  renderPersons();
+  renderParticipantSelector();
+  renderExpenses();
+  renderSummary();
+  updateAnalyzeButtonState();
+  updateExperimentalDefaultMessage();
+})();

--- a/index.css
+++ b/index.css
@@ -415,6 +415,21 @@ a:focus-visible {
   gap: 0.5rem;
 }
 
+.home-card--sharing .home-card__badge {
+  background: rgba(255, 159, 89, 0.18);
+  color: #ffb169;
+}
+
+.home-card--sharing .link-button {
+  background: rgba(255, 159, 89, 0.14);
+  border-color: rgba(255, 159, 89, 0.25);
+}
+
+.home-card--sharing .link-button:hover {
+  background: rgba(255, 159, 89, 0.2);
+  border-color: rgba(255, 159, 89, 0.4);
+}
+
 .link-button {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -56,6 +56,19 @@
                 <button type="button" class="link-button" data-nav-target="digital-mode">Digital Mode</button>
               </div>
             </article>
+            <article class="home-card home-card--sharing">
+              <div class="home-card__badge">Neu im Toolkit</div>
+              <h2>Kosten &amp; Rechnungen</h2>
+              <p>
+                Teile gemeinsame Ausgaben gerecht auf. Erfasse Rechnungen, tagge Personen und erhalte direkt
+                faire Beträge pro Kopf.
+              </p>
+              <div class="home-card__links">
+                <button type="button" class="link-button" data-nav-target="bill-splitter">
+                  Kostenkalkulation
+                </button>
+              </div>
+            </article>
             <article class="home-card home-card--anime">
               <h2>Anime Charakter Rätsel</h2>
               <p>Teste dein Wissen mit dem Rätsel-Chat oder pflege den zugrunde liegenden Charakter-Datensatz.</p>

--- a/pages.js
+++ b/pages.js
@@ -6,6 +6,7 @@ const pages = [
   { title: 'Playlist → QR Cards', url: 'generator.html' },
   { title: 'Play Screen', url: 'gameModeScan.html' },
   { title: 'Digital Mode', url: 'gameModeDigital.html' },
+  { title: 'Kostenkalkulation', url: 'bill-splitter.html' },
   { title: 'Anidle', url: 'anidle.html' },
   { title: 'Anidle Debug', url: 'anidleDebug.html' },
   { title: 'Anime Rätsel Chat', url: 'animeCharakterdle.html' },


### PR DESCRIPTION
## Summary
- create a dedicated bill-splitter tool to capture people and shared expenses with fair rounding logic
- add navigation and landing page entry points for the new cost calculator
- wire an experimental receipt AI prefill option that becomes available via the `receiptAI` URL parameter

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9730a0130832f84248ad33a5367ed