### PR TITLE
Improve bill splitter summary layout and auto-select option

### DIFF
--- a/bill-splitter.css
+++ b/bill-splitter.css
@@ -377,6 +377,58 @@ textarea:focus {
   font-size: 0.9rem;
 }
 
+.form-toggle {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(78, 205, 196, 0.2);
+  background: rgba(11, 22, 38, 0.65);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-toggle:hover {
+  border-color: rgba(78, 205, 196, 0.45);
+  box-shadow: 0 14px 32px -28px rgba(78, 205, 196, 0.6);
+}
+
+.form-toggle--disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.form-toggle__input {
+  flex: 0 0 auto;
+  margin-top: 0.2rem;
+  transform: scale(1.05);
+  accent-color: var(--primary);
+}
+
+.form-toggle__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--muted-strong);
+}
+
+.form-toggle__title {
+  color: var(--text-strong);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.form-toggle__hint {
+  font-size: 0.8rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
 .expense-list {
   display: grid;
   gap: 1rem;
@@ -447,23 +499,47 @@ textarea:focus {
   box-shadow: 0 14px 30px -24px rgba(78, 205, 196, 0.8);
 }
 
+.card--summary {
+  gap: 1rem;
+}
+
+.summary-content {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.summary-content__primary {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 960px) {
+  .summary-content {
+    grid-template-columns: minmax(0, 1.7fr) minmax(220px, 1fr);
+    align-items: start;
+  }
+}
+
 .summary-table-wrapper {
   overflow-x: auto;
-  border-radius: 1.1rem;
+  overflow-y: hidden;
+  border-radius: 1rem;
   border: 1px solid rgba(78, 205, 196, 0.18);
+  background: rgba(10, 24, 38, 0.6);
+  box-shadow: var(--shadow-sm);
 }
 
 .summary-table {
   width: 100%;
   border-collapse: collapse;
-  min-width: 520px;
+  min-width: 0;
 }
 
 .summary-table th,
 .summary-table td {
-  padding: 0.75rem 1rem;
+  padding: 0.65rem 0.85rem;
   text-align: left;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .summary-table thead {
@@ -472,53 +548,213 @@ textarea:focus {
 }
 
 .summary-table tbody tr:nth-child(odd) {
-  background: rgba(10, 22, 36, 0.55);
+  background: rgba(9, 21, 36, 0.45);
+}
+
+.summary-table__row {
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.summary-table__row:hover {
+  background: rgba(78, 205, 196, 0.12);
+}
+
+.summary-table__name {
+  font-weight: 600;
+  font-size: 0.98rem;
+  letter-spacing: 0.01em;
+}
+
+.summary-table__cell {
+  font-size: 0.9rem;
+  color: var(--muted-strong);
+  position: relative;
+}
+
+.summary-table__cell::before {
+  content: none;
+}
+
+.summary-table__cell--highlight {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.summary-table__cell--diff[data-state='plus'] {
+  color: var(--success);
+}
+
+.summary-table__cell--diff[data-state='minus'] {
+  color: var(--danger);
+}
+
+.summary-table__cell--diff[data-state='even'] {
+  color: var(--muted);
 }
 
 .summary-breakdown {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.75rem;
 }
 
 .summary-breakdown details {
-  background: rgba(12, 23, 40, 0.7);
-  border: 1px solid rgba(78, 205, 196, 0.18);
-  border-radius: 0.85rem;
-  padding: 0.6rem 0.8rem;
+  background: rgba(10, 24, 38, 0.6);
+  border: 1px solid rgba(78, 205, 196, 0.2);
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.95rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.summary-breakdown details[open] {
+  border-color: rgba(78, 205, 196, 0.35);
+  background: rgba(12, 30, 50, 0.65);
 }
 
 .summary-breakdown summary {
   cursor: pointer;
   font-weight: 600;
   color: var(--muted-strong);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+}
+
+.summary-breakdown summary::after {
+  content: '▾';
+  font-size: 0.8rem;
+  color: var(--muted);
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.summary-breakdown summary::-webkit-details-marker {
+  display: none;
+}
+
+.summary-breakdown details[open] summary::after {
+  transform: rotate(-180deg);
+  color: var(--primary);
 }
 
 .summary-breakdown ul {
-  margin: 0.5rem 0 0;
+  margin: 0.65rem 0 0;
   padding-left: 1.2rem;
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
 }
 
 .summary-totals {
   display: grid;
-  gap: 0.45rem;
-  font-size: 0.95rem;
+  gap: 0.75rem;
+  background: rgba(10, 24, 38, 0.72);
+  border: 1px solid rgba(78, 205, 196, 0.2);
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .summary-total {
   display: flex;
-  justify-content: space-between;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
-.summary-total--accent {
+.summary-total span {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.summary-total strong {
+  font-size: 1.05rem;
+  color: var(--text-strong);
+}
+
+.summary-total--accent strong {
   color: var(--primary);
 }
 
 .summary-note {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--muted);
+  line-height: 1.4;
+}
+
+@media (max-width: 960px) {
+  .summary-totals {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .summary-table th,
+  .summary-table td {
+    padding: 0.55rem 0.7rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .summary-content {
+    gap: 1.1rem;
+  }
+
+  .summary-table-wrapper {
+    overflow: visible;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .summary-table thead {
+    display: none;
+  }
+
+  .summary-table tbody {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .summary-table__row {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.45rem 0.75rem;
+    padding: 0.85rem 1rem;
+    border-radius: 1rem;
+    background: rgba(10, 24, 38, 0.72);
+    border: 1px solid rgba(78, 205, 196, 0.2);
+    box-shadow: 0 24px 45px -36px rgba(3, 10, 21, 0.9);
+  }
+
+  .summary-table__name {
+    grid-column: 1 / -1;
+    font-size: 1.05rem;
+  }
+
+  .summary-table__cell {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3rem;
+    font-size: 0.95rem;
+  }
+
+  .summary-table__cell::before {
+    content: attr(data-label);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted-strong);
+  }
+
+  .summary-table__cell--highlight {
+    color: var(--primary);
+  }
+
+  .summary-table__cell--diff {
+    font-weight: 600;
+  }
 }
 
 .summary-unassigned {

--- a/bill-splitter.html
+++ b/bill-splitter.html
@@ -84,6 +84,21 @@
             <fieldset class="form-fieldset">
               <legend>Personen-Tagging</legend>
               <div id="expenseParticipants" class="participant-selector"></div>
+              <label class="form-toggle" for="autoSelectAllToggle">
+                <input
+                  type="checkbox"
+                  id="autoSelectAllToggle"
+                  class="form-toggle__input"
+                  autocomplete="off"
+                />
+                <div class="form-toggle__content">
+                  <span class="form-toggle__title">Alle Personen automatisch auswählen</span>
+                  <span class="form-toggle__hint"
+                    >Neue Ausgaben starten direkt mit allen Personen markiert. Du kannst die
+                    Auswahl jederzeit anpassen.</span
+                  >
+                </div>
+              </label>
             </fieldset>
             <div class="form-actions">
               <button type="submit" class="button button--primary">Ausgabe speichern</button>
@@ -111,27 +126,38 @@
           <div id="summaryEmpty" class="empty-state">
             Füge Personen und Ausgaben hinzu, um die Aufteilung zu berechnen.
           </div>
-          <div id="summaryTableWrapper" class="summary-table-wrapper" hidden>
-            <table class="summary-table">
-              <thead>
-                <tr>
-                  <th scope="col">Person</th>
-                  <th scope="col">Zwischensumme</th>
-                  <th scope="col">Aufgerundet</th>
-                  <th scope="col">Aufschlag</th>
-                </tr>
-              </thead>
-              <tbody id="summaryBody"></tbody>
-            </table>
-          </div>
-          <div id="personBreakdown" class="summary-breakdown"></div>
-          <div id="summaryTotals" class="summary-totals" hidden>
-            <div class="summary-total"><span>Gesamtausgaben:</span> <strong id="totalsActual"></strong></div>
-            <div class="summary-total"><span>Summe aufgerundet:</span> <strong id="totalsRounded"></strong></div>
-            <div class="summary-total summary-total--accent">
-              <span>Aufrundungsreserve:</span> <strong id="roundingDifference"></strong>
+          <div id="summaryContent" class="summary-content" hidden>
+            <div class="summary-content__primary">
+              <div id="summaryTableWrapper" class="summary-table-wrapper" hidden>
+                <table class="summary-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Person</th>
+                      <th scope="col">Zwischensumme</th>
+                      <th scope="col">Aufgerundet</th>
+                      <th scope="col">Aufschlag</th>
+                    </tr>
+                  </thead>
+                  <tbody id="summaryBody"></tbody>
+                </table>
+              </div>
+              <div id="personBreakdown" class="summary-breakdown"></div>
             </div>
-            <p id="roundingNote" class="summary-note"></p>
+            <aside id="summaryTotals" class="summary-totals" hidden>
+              <div class="summary-total">
+                <span>Gesamtausgaben</span>
+                <strong id="totalsActual"></strong>
+              </div>
+              <div class="summary-total">
+                <span>Summe aufgerundet</span>
+                <strong id="totalsRounded"></strong>
+              </div>
+              <div class="summary-total summary-total--accent">
+                <span>Aufrundungsreserve</span>
+                <strong id="roundingDifference"></strong>
+              </div>
+              <p id="roundingNote" class="summary-note"></p>
+            </aside>
           </div>
           <p id="unassignedInfo" class="summary-unassigned" hidden></p>
         </section>


### PR DESCRIPTION
## Summary
- add a toggle to preselect all people on new expenses, including supporting logic and styling
- redesign the per-person cost summary with a responsive layout, mobile-friendly table cards and compact totals card

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c986517f10832fa88843b94cf613d4