### PR TITLE
Refine embedded content experience

### DIFF
--- a/app.js
+++ b/app.js
@@ -255,6 +255,7 @@
   const frameDescriptionEl = document.getElementById('frameDescription');
   const openExternalBtn = document.getElementById('openExternal');
   const configGridEl = document.getElementById('configGrid');
+  const frameViewEl = viewMap.frame;
 
   const navIndex = new Map();
   const navButtons = new Map();
@@ -440,6 +441,9 @@
     document.title = 'Behamot Toolkit';
     frameEl.dataset.src = frameEl.dataset.src || '';
     openExternalBtn.hidden = true;
+    if (frameViewEl) {
+      frameViewEl.classList.remove('view--frame-header-hidden');
+    }
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
@@ -478,6 +482,10 @@
     document.title = `Behamot Toolkit – ${item.label}`;
     frameTitleEl.textContent = item.label;
 
+    if (frameViewEl) {
+      frameViewEl.classList.remove('view--frame-header-hidden');
+    }
+
     if (item.description) {
       frameDescriptionEl.textContent = item.description;
       frameDescriptionEl.hidden = false;
@@ -497,9 +505,33 @@
       frameEl.classList.add('content-frame--loading');
       frameEl.dataset.src = currentFrameUrl;
       frameEl.src = currentFrameUrl || 'about:blank';
+    } else {
+      handleFrameLoad();
     }
 
     window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function handleFrameLoad() {
+    frameEl.classList.remove('content-frame--loading');
+
+    if (!frameViewEl) return;
+
+    try {
+      const doc = frameEl.contentDocument;
+      if (!doc) {
+        frameViewEl.classList.remove('view--frame-header-hidden');
+        return;
+      }
+
+      const hasPageHeader = Boolean(
+        doc.querySelector('header, .page-header, .app-header, [data-page-header]')
+      );
+
+      frameViewEl.classList.toggle('view--frame-header-hidden', hasPageHeader);
+    } catch (error) {
+      frameViewEl.classList.remove('view--frame-header-hidden');
+    }
   }
 
   function buildConfigCards() {
@@ -639,9 +671,7 @@
   }
 
   function bindFrameLoading() {
-    frameEl.addEventListener('load', () => {
-      frameEl.classList.remove('content-frame--loading');
-    });
+    frameEl.addEventListener('load', handleFrameLoad);
 
     openExternalBtn.addEventListener('click', () => {
       if (!currentFrameUrl) return;

--- a/index.css
+++ b/index.css
@@ -48,6 +48,18 @@ a:hover {
   color: var(--accent-strong);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 button {
   font: inherit;
   color: inherit;
@@ -238,6 +250,18 @@ a:focus-visible {
   display: block;
 }
 
+.view--frame {
+  position: relative;
+}
+
+.view--frame.view--frame-header-hidden .view-header {
+  display: none;
+}
+
+.view--frame.view--frame-header-hidden .frame-wrapper {
+  margin-top: 0;
+}
+
 .view-header {
   display: flex;
   flex-wrap: wrap;
@@ -257,12 +281,6 @@ a:focus-visible {
   margin: 0;
   max-width: 700px;
   color: var(--muted);
-}
-
-.view-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
 }
 
 .hero-card {
@@ -618,21 +636,50 @@ a:focus-visible {
   }
 }
 
+
 .frame-wrapper {
-  border-radius: 1.5rem;
-  border: 1px solid var(--surface-border);
-  background: rgba(8, 14, 28, 0.85);
-  padding: 0.65rem;
-  box-shadow: var(--shadow-md);
+  position: relative;
   min-height: 65vh;
+  border-radius: 1.35rem;
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(10, 18, 35, 0.62), rgba(4, 9, 21, 0.82));
+  margin-top: 0.75rem;
 }
 
 .content-frame {
+  display: block;
   width: 100%;
-  height: min(78vh, 900px);
+  height: min(82vh, 940px);
   border: none;
-  border-radius: 1.2rem;
-  background: #050b1a;
+  background: transparent;
+}
+
+.frame-external-button {
+  position: absolute;
+  top: 0.9rem;
+  right: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(78, 205, 196, 0.35);
+  background: rgba(6, 17, 36, 0.6);
+  color: var(--accent);
+  box-shadow: 0 18px 38px -28px rgba(4, 10, 26, 0.85);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.frame-external-button:hover {
+  background: rgba(78, 205, 196, 0.14);
+  color: var(--accent-strong);
+  transform: translateY(-1px);
+}
+
+.frame-external-button__icon {
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
 .content-frame--loading {

--- a/index.html
+++ b/index.html
@@ -108,19 +108,24 @@
           <div id="configGrid" class="config-grid" aria-live="polite"></div>
         </section>
 
-        <section id="frameView" class="view" aria-labelledby="frameTitle" hidden>
+        <section id="frameView" class="view view--frame" aria-labelledby="frameTitle" hidden>
           <header class="view-header">
             <div>
               <h1 id="frameTitle"></h1>
               <p id="frameDescription" class="view-subline"></p>
             </div>
-            <div class="view-actions">
-              <button type="button" id="openExternal" class="button button--ghost" hidden>
-                In neuem Tab öffnen
-              </button>
-            </div>
           </header>
           <div class="frame-wrapper">
+            <button
+              type="button"
+              id="openExternal"
+              class="frame-external-button"
+              hidden
+              aria-label="In neuem Tab öffnen"
+            >
+              <span class="sr-only">In neuem Tab öffnen</span>
+              <span aria-hidden="true" class="frame-external-button__icon">↗︎</span>
+            </button>
             <iframe id="contentFrame" title="Arbeitsbereich" loading="lazy" class="content-frame"></iframe>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- blend the embedded content area into the page layout and move the external-open control into a subtle corner trigger
- add styling utilities for visually hidden labels and frame-specific presentation tweaks, including the floating external button
- detect headers inside embedded pages so the host view avoids rendering a duplicate heading when tools provide their own

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ca5f481500832fae451d88d9162d85