### PR TITLE
Make deploy workflow optional for npm builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,16 +12,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        if: hashFiles('package.json') != ''
+        run: npm install
+
       - name: Build (optional)
+        if: hashFiles('package.json') != ''
+        run: npm run build
+
+      - name: Determine deploy path
+        id: deploy-path
         run: |
-          npm install
-          npm run build
+          if [ -d dist ]; then
+            echo "path=dist/" >> "$GITHUB_OUTPUT"
+          elif [ -d build ]; then
+            echo "path=build/" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=." >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Deploy via rsync/ssh
         uses: burnett01/rsync-deployments@7.1.0
         with:
-          switches: -avzr --delete
-          path: dist/           # oder . für statische Dateien
+          switches: -avzr --delete --exclude '.git/' --exclude '.github/'
+          path: ${{ steps.deploy-path.outputs.path }}
           remote_path: /var/www/behamot.de/
           remote_host: 213.160.73.172
           remote_user: deploy


### PR DESCRIPTION
## Summary
- make npm install/build steps conditional on the presence of package.json
- add a step that selects an existing deployment directory (dist, build, or repository root)
- exclude Git metadata directories from rsync deployments to avoid copying CI configuration

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc6a316588832fa1f8eac836c2a21a