### PR TITLE
Fix rsync deployment permission error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,10 @@ jobs:
             echo "path=." >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Ensure workspace permissions
+        run: |
+          chmod -R a+rX .git
+
       - name: Deploy via rsync/ssh
         uses: burnett01/rsync-deployments@7.1.0
         with:


### PR DESCRIPTION
## Summary
- add a workflow step that opens read and execute permissions on the checkout's .git directory before deploying
- this allows the rsync deployment container to read Git metadata without triggering permission denied errors

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd0e5b3d0c832fb206cb5f9584851b