### PR TITLE
Add Docker deployment setup for frontend and backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+*.Dockerfile
+Dockerfile
+Dockerfile.*
+docker-compose.yml
+README.md
+node_modules
+anime-dataset/*
+!anime-dataset/public
+!anime-dataset/public/**
+docker/*
+!docker/nginx
+!docker/nginx/default.conf
+secrets/
+.env*

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Backend configuration
+BACKEND_PORT=3000
+BACKEND_DATASET_PATH=/app/dataset/characters.jsonl
+BACKEND_API_TOKEN=change-me
+
+# Frontend configuration
+FRONTEND_BACKEND_API_BASE=http://backend:3000
+
+# Third-party secrets (populate as needed)
+OPENAI_API_KEY=
+RIOT_API_KEY=
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+FROM nginx:1.27-alpine
+
+# Copy nginx configuration with backend proxy setup
+COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+
+# Copy static assets into nginx document root
+COPY --chown=nginx:nginx . /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s CMD wget --spider -q http://localhost/ || exit 1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# Container Deployment Guide
+
+Diese Dokumentation beschreibt, wie das Projekt mithilfe von Docker-Containern bereitgestellt wird. Der Stack besteht aus einem Node.js-Backend ("anime-dataset" Service) und einem statischen Frontend, das via nginx ausgeliefert wird. Die Container werden mit `docker compose` orchestriert.
+
+## Verzeichnisstruktur
+
+- `anime-dataset/`: Node.js-Backend-Service inklusive API und Datensatz-Verwaltung.
+- `Dockerfile.frontend`: Build-Anleitung für das nginx-Frontend.
+- `anime-dataset/Dockerfile`: Build-Anleitung für den Backend-Service.
+- `docker-compose.yml`: Definition der Services, Netzwerke und Volumes.
+- `docker/nginx/default.conf`: nginx-Konfiguration mit Proxy-Regeln für `/api`.
+- `.env.example`: Vorlage für benötigte Umgebungsvariablen.
+
+## Vorbereitung von Secrets & Umgebungsvariablen
+
+1. Kopiere `.env.example` zu `.env` (wird von Docker Compose automatisch geladen) und fülle alle Werte aus:
+   ```bash
+   cp .env.example .env
+   # Werte wie BACKEND_API_TOKEN, OPENAI_API_KEY etc. ergänzen
+   ```
+2. Sensible Dateien sollten **nicht** eingecheckt werden. Das Repository ignoriert `.env*` Dateien bereits über `.gitignore` und `.dockerignore`.
+3. Auf dem Server sollten Secrets via `scp` oder einem Secret-Management-Tool (z. B. sops, Ansible Vault, HashiCorp Vault) abgelegt werden. Passe die Dateiberechtigungen an (`chmod 600 .env`).
+
+## Docker-Images bauen und starten
+
+Voraussetzungen: Docker Engine ≥ 24 und Docker Compose Plugin.
+
+```bash
+# Images bauen und Container im Hintergrund starten
+BACKEND_API_TOKEN=geheim docker compose up -d --build
+
+# Logs prüfen
+docker compose logs -f backend
+```
+
+Der Befehl `docker compose up -d --build` baut beide Images (`backend`, `frontend`), erstellt die Netzwerke (`internal`, `public`) und startet die Container im Hintergrund. Das Frontend ist anschließend unter `http://localhost:8080` erreichbar. Interne Aufrufe an `/api/*` werden automatisch an den Backend-Service weitergeleitet.
+
+### Datenpersistenz
+
+- Das Backend schreibt den Datensatz nach `/app/dataset/characters.jsonl`. Über das Compose-Volume `./anime-dataset/dataset:/app/dataset` bleiben Änderungen auf dem Host erhalten.
+- Alternativ kann ein Docker-Volume verwendet werden:
+  ```yaml
+  volumes:
+    - anime-dataset-data:/app/dataset
+  ```
+
+## Deployment auf einem Server
+
+1. Repository klonen oder Artefakte per CI/CD bereitstellen.
+2. `.env` und ggf. weitere Secret-Dateien (z. B. Zertifikate) via `scp` auf den Server kopieren.
+3. Optional: `docker compose pull` verwenden, falls die Images in einer Registry liegen.
+4. `docker compose up -d` ausführen.
+5. `docker compose ps` bzw. `docker compose logs` zur Überwachung nutzen.
+
+### Reverse Proxy & HTTPS
+
+Für ein öffentliches Deployment empfiehlt sich ein vorgelagerter Reverse Proxy:
+
+- **Traefik**: Container zum `public`-Netzwerk hinzufügen und Labels in `docker-compose.yml` ergänzen.
+- **Caddy** oder **Nginx**: Eigenen Proxy-Container starten (ebenfalls im `public`-Netzwerk), der TLS-Zertifikate (z. B. via Let's Encrypt) verwaltet und eingehende Anfragen auf `frontend:80` weiterleitet.
+- Achte darauf, HTTPS zu erzwingen und sensible Header (`X-Forwarded-Proto`, `X-Forwarded-For`) zu setzen.
+
+Beispiel für ein zusätzliches Traefik-Label im `frontend`-Service:
+```yaml
+labels:
+  - traefik.enable=true
+  - traefik.http.routers.toolkit.rule=Host(`toolkit.example.com`)
+  - traefik.http.routers.toolkit.entrypoints=websecure
+  - traefik.http.routers.toolkit.tls.certresolver=letsencrypt
+```
+
+## Weiterentwicklung & Troubleshooting
+
+- **Lokale Tests**: Mit `docker compose up` ohne `-d` starten, um Logs direkt im Terminal zu verfolgen.
+- **Konfigurationsänderungen**: Nach Anpassungen an Dockerfiles oder `docker-compose.yml` den Stack mit `docker compose up -d --build` neu deployen.
+- **Backend-Variablen**: `PORT` und `DATASET_PATH` lassen sich via `.env` überschreiben.
+- **Fehlersuche**: `docker compose exec backend sh` öffnet eine Shell im Backend-Container.
+
+Für Erweiterungen (z. B. zusätzliche Services, Worker, Cronjobs) empfiehlt sich, eigene Netzwerke oder Compose-Profile zu definieren. Dokumentiere neue Umgebungsvariablen stets in `.env.example`.

--- a/anime-dataset/.dockerignore
+++ b/anime-dataset/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+*.env

--- a/anime-dataset/Dockerfile
+++ b/anime-dataset/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Install dependencies using a clean install for reproducible builds
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy source files
+COPY . .
+
+# Ensure runtime user exists and owns the dataset directory
+RUN addgroup -S app && adduser -S -G app app \
+    && mkdir -p dataset \
+    && chown -R app:app /app
+
+USER app
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/anime-dataset/package.json
+++ b/anime-dataset/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/anime-dataset/server.js
+++ b/anime-dataset/server.js
@@ -5,8 +5,10 @@ import bodyParser from "body-parser";
 import cors from "cors";
 
 const app = express();
-const PORT = 3000;
-const DATASET_PATH = path.resolve("dataset/characters.jsonl");
+const PORT = Number.parseInt(process.env.PORT, 10) || 3000;
+const DATASET_PATH = path.resolve(
+  process.env.DATASET_PATH ?? "dataset/characters.jsonl"
+);
 
 app.use(cors());
 app.use(bodyParser.json({ limit: "10mb" }));
@@ -22,6 +24,7 @@ function loadCharacters() {
 // Dataset speichern
 function saveCharacters(chars) {
   const text = chars.map(c => JSON.stringify(c)).join("\n");
+  fs.mkdirSync(path.dirname(DATASET_PATH), { recursive: true });
   fs.writeFileSync(DATASET_PATH, text, "utf-8");
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./anime-dataset
+    image: behamot007/anime-backend:latest
+    environment:
+      - NODE_ENV=production
+      - PORT=${BACKEND_PORT:-3000}
+      - DATASET_PATH=${BACKEND_DATASET_PATH:-/app/dataset/characters.jsonl}
+      - API_TOKEN=${BACKEND_API_TOKEN:-}
+    volumes:
+      - ./anime-dataset/dataset:/app/dataset
+    networks:
+      - internal
+    expose:
+      - "${BACKEND_PORT:-3000}"
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    image: behamot007/anime-frontend:latest
+    depends_on:
+      - backend
+    environment:
+      - BACKEND_API_BASE=${FRONTEND_BACKEND_API_BASE:-http://backend:3000}
+    ports:
+      - "8080:80"
+    networks:
+      - internal
+      - public
+
+networks:
+  internal:
+    driver: bridge
+  public:
+    driver: bridge

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,23 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript application/octet-stream image/svg+xml;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add a production-ready Dockerfile for the anime-dataset Node.js backend with npm ci, npm run start, and environment overrides for port and dataset path
- add an nginx-based frontend Dockerfile, reverse-proxy configuration, and a docker-compose.yml with isolated networks and environment variable injection for secrets
- document container deployment steps, secret handling, persistence, and reverse proxy guidance in the README and environment examples

## Testing
- not run (docker CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd2cb09ea8832f968a28561f428301