### PR TITLE
Add persistent PostgreSQL service configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ BACKEND_API_TOKEN=change-me
 # Frontend configuration
 FRONTEND_BACKEND_API_BASE=http://backend:3000
 
+# PostgreSQL database (optional service)
+POSTGRES_DB=app
+POSTGRES_USER=app
+POSTGRES_PASSWORD=change-me
+POSTGRES_PORT=5432
+
 # Third-party secrets (populate as needed)
 OPENAI_API_KEY=
 RIOT_API_KEY=

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ Der Befehl `docker compose up -d --build` baut beide Images (`backend`, `fronten
     - anime-dataset-data:/app/dataset
   ```
 
+### Persistente PostgreSQL-Datenbank
+
+Für zusätzliche Services, die eine relationale Datenbank benötigen, steht ein vorkonfigurierter PostgreSQL-Container bereit:
+
+```yaml
+postgres:
+  image: postgres:15
+  restart: unless-stopped
+  environment:
+    POSTGRES_DB: ${POSTGRES_DB:-app}
+    POSTGRES_USER: ${POSTGRES_USER:-app}
+    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+  volumes:
+    - postgres_data:/var/lib/postgresql/data
+  ports:
+    - "${POSTGRES_PORT:-5432}:5432"
+```
+
+- Über das benannte Volume `postgres_data` bleiben Daten über Container-Neustarts hinweg erhalten.
+- Mit `restart: unless-stopped` startet der Datenbank-Container automatisch nach einem Server-Reboot.
+- Passe die Zugangsdaten in `.env` an und hinterlege starke Passwörter oder verwende ein Secret-Management.
+- Für Backups können `pg_dump` oder Automatisierungstools wie `pgBackRest` eingesetzt werden.
+
 ## Deployment auf einem Server
 
 1. Repository klonen oder Artefakte per CI/CD bereitstellen.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,25 @@
 
 services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-app}
+      - POSTGRES_USER=${POSTGRES_USER:-app}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-change-me}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    networks:
+      - internal
+
   backend:
     build:
       context: ./anime-dataset
     image: behamot007/anime-backend:latest
+    depends_on:
+      - postgres
     environment:
       - NODE_ENV=production
       - PORT=${BACKEND_PORT:-3000}
@@ -36,3 +52,7 @@ networks:
     driver: bridge
   public:
     driver: bridge
+
+volumes:
+  postgres_data:
+    driver: local


### PR DESCRIPTION
## Summary
- add a postgres service with a persistent volume to docker-compose.yml
- document how to use the new database container and configure credentials
- extend .env.example with postgres-related environment variables

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da72e8452c832fad91adb752e50f66