### PR TITLE
Add script to preserve existing .env during deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ docker/*
 !docker/nginx/default.conf
 secrets/
 .env*
+scripts/

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ Diese Dokumentation beschreibt, wie das Projekt mithilfe von Docker-Containern b
 
 ## Vorbereitung von Secrets & Umgebungsvariablen
 
-1. Kopiere `.env.example` zu `.env` (wird von Docker Compose automatisch geladen) und fülle alle Werte aus:
+1. Erstelle die lokale `.env` **nur einmalig** aus der Vorlage – entweder manuell oder via Skript:
    ```bash
-   cp .env.example .env
-   # Werte wie BACKEND_API_TOKEN, OPENAI_API_KEY etc. ergänzen
+   # legt die Datei nur an, falls sie noch nicht existiert
+   ./scripts/ensure-env.sh
    ```
-2. Sensible Dateien sollten **nicht** eingecheckt werden. Das Repository ignoriert `.env*` Dateien bereits über `.gitignore` und `.dockerignore`.
-3. Auf dem Server sollten Secrets via `scp` oder einem Secret-Management-Tool (z. B. sops, Ansible Vault, HashiCorp Vault) abgelegt werden. Passe die Dateiberechtigungen an (`chmod 600 .env`).
+   Alternativ kann `cp -n .env.example .env` verwendet werden (`-n` verhindert ein Überschreiben bestehender Dateien).
+2. Ergänze anschließend alle benötigten Werte (z. B. `BACKEND_API_TOKEN`, `OPENAI_API_KEY`). Bei Updates der Vorlage können Unterschiede mit `diff -u .env .env.example` geprüft und selektiv übernommen werden.
+3. Sensible Dateien sollten **nicht** eingecheckt werden. Das Repository ignoriert `.env*` Dateien bereits über `.gitignore` und `.dockerignore`.
+4. Auf dem Server sollten Secrets via `scp` oder einem Secret-Management-Tool (z. B. sops, Ansible Vault, HashiCorp Vault) abgelegt werden. Passe die Dateiberechtigungen an (`chmod 600 .env`).
 
 ## Docker-Images bauen und starten
 

--- a/scripts/ensure-env.sh
+++ b/scripts/ensure-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE=".env"
+EXAMPLE_FILE=".env.example"
+
+if [[ ! -f "$EXAMPLE_FILE" ]]; then
+  echo "Vorlage $EXAMPLE_FILE wurde nicht gefunden." >&2
+  exit 1
+fi
+
+if [[ -f "$ENV_FILE" ]]; then
+  echo "Bestehende $ENV_FILE gefunden. Datei bleibt unverändert." >&2
+  echo "Prüfe Unterschiede mit: diff -u $ENV_FILE $EXAMPLE_FILE || true" >&2
+  exit 0
+fi
+
+cp "$EXAMPLE_FILE" "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+echo "$ENV_FILE aus $EXAMPLE_FILE erstellt. Bitte Werte aktualisieren."


### PR DESCRIPTION
## Summary
- add a helper script that only creates .env from the example when it is missing
- document the new workflow in the deployment guide and explain how to review updates
- exclude the helper script from Docker build contexts

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68db8fd02bf0832f948b9813225a3a33