### PR TITLE
Route Spotify API calls through backend

### DIFF
--- a/anime-dataset/server.js
+++ b/anime-dataset/server.js
@@ -4,15 +4,137 @@ import path from "path";
 import bodyParser from "body-parser";
 import cors from "cors";
 
+function loadEnvFile() {
+  const envPath = path.resolve(process.cwd(), ".env");
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
+  try {
+    const content = fs.readFileSync(envPath, "utf-8");
+    content
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith("#"))
+      .forEach(line => {
+        const equalsIndex = line.indexOf("=");
+        if (equalsIndex === -1) return;
+        const key = line.slice(0, equalsIndex).trim();
+        const value = line.slice(equalsIndex + 1).trim();
+        if (!key || process.env[key] !== undefined) return;
+        const unquoted = value.replace(/^['"]|['"]$/g, "");
+        process.env[key] = unquoted;
+      });
+  } catch (error) {
+    console.warn(".env konnte nicht gelesen werden:", error);
+  }
+}
+
+loadEnvFile();
+
 const app = express();
 const PORT = Number.parseInt(process.env.PORT, 10) || 3000;
 const DATASET_PATH = path.resolve(
   process.env.DATASET_PATH ?? "dataset/characters.jsonl"
 );
+const SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "";
+const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "";
+
+let cachedSpotifyToken = "";
+let cachedSpotifyTokenExpiry = 0;
 
 app.use(cors());
 app.use(bodyParser.json({ limit: "10mb" }));
 app.use(express.static("public")); // Hier liegt index.html
+
+function ensureSpotifyCredentials() {
+  if (!SPOTIFY_CLIENT_ID || !SPOTIFY_CLIENT_SECRET) {
+    const error = new Error("Spotify credentials are not configured");
+    error.status = 503;
+    throw error;
+  }
+}
+
+async function requestSpotifyClientCredentialsToken() {
+  ensureSpotifyCredentials();
+
+  if (cachedSpotifyToken && Date.now() < cachedSpotifyTokenExpiry - 60000) {
+    return cachedSpotifyToken;
+  }
+
+  const params = new URLSearchParams({ grant_type: "client_credentials" });
+  const response = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${Buffer.from(
+        `${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`
+      ).toString("base64")}`
+    },
+    body: params.toString()
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    const message = data?.error_description || data?.error || "Spotify token request failed";
+    const error = new Error(message);
+    error.status = response.status || 500;
+    error.details = data;
+    throw error;
+  }
+
+  cachedSpotifyToken = data.access_token;
+  const expiresIn = typeof data.expires_in === "number" ? data.expires_in : 3600;
+  cachedSpotifyTokenExpiry = Date.now() + expiresIn * 1000;
+  return cachedSpotifyToken;
+}
+
+async function fetchSpotifyPlaylistTracks(playlistId) {
+  if (!playlistId) {
+    const error = new Error("Playlist ID is required");
+    error.status = 400;
+    throw error;
+  }
+
+  const token = await requestSpotifyClientCredentialsToken();
+  let url = `https://api.spotify.com/v1/playlists/${playlistId}/tracks?limit=100`;
+  const tracks = [];
+
+  while (url) {
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      const message = data?.error?.message || "Spotify playlist request failed";
+      const error = new Error(message);
+      error.status = response.status || 500;
+      error.details = data;
+      throw error;
+    }
+
+    for (const item of data.items ?? []) {
+      if (!item?.track) continue;
+      const album = item.track.album ?? {};
+      const releaseDate = album.release_date ?? "";
+      tracks.push({
+        name: item.track.name,
+        artist: (item.track.artists ?? []).map(artist => artist.name).join(", "),
+        url: item.track.external_urls?.spotify ?? "",
+        cover: album.images?.[0]?.url ?? "",
+        year: releaseDate,
+        preview: item.track.preview_url ?? null
+      });
+    }
+
+    url = data.next;
+  }
+
+  return tracks;
+}
 
 // Dataset laden
 function loadCharacters() {
@@ -72,6 +194,113 @@ app.post("/api/characters", (req, res) => {
     res.json({ status: "ok" });
   } catch (error) {
     res.status(500).json({ error: "Failed to persist dataset" });
+  }
+});
+
+app.get("/api/spotify/config", (req, res) => {
+  res.json({
+    clientId: SPOTIFY_CLIENT_ID || null,
+    hasClientSecret: Boolean(SPOTIFY_CLIENT_SECRET)
+  });
+});
+
+app.get("/api/spotify/playlists/:playlistId/tracks", async (req, res) => {
+  try {
+    const tracks = await fetchSpotifyPlaylistTracks(req.params.playlistId);
+    res.json({ tracks });
+  } catch (error) {
+    console.error("Spotify playlist error:", error);
+    res.status(error.status || 500).json({
+      error: error.message || "Failed to fetch playlist",
+      details: error.details ?? null
+    });
+  }
+});
+
+app.post("/api/spotify/token", async (req, res) => {
+  try {
+    ensureSpotifyCredentials();
+    const { code, redirectUri } = req.body ?? {};
+    if (!code || !redirectUri) {
+      return res.status(400).json({ error: "code and redirectUri are required" });
+    }
+
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri
+    });
+
+    const response = await fetch("https://accounts.spotify.com/api/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${Buffer.from(
+          `${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`
+        ).toString("base64")}`
+      },
+      body: params.toString()
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      const message = data?.error_description || data?.error || "Spotify authorization failed";
+      return res.status(response.status || 500).json({
+        error: message,
+        details: data
+      });
+    }
+
+    res.json(data);
+  } catch (error) {
+    console.error("Spotify auth error:", error);
+    res.status(error.status || 500).json({
+      error: error.message || "Spotify token exchange failed",
+      details: error.details ?? null
+    });
+  }
+});
+
+app.post("/api/spotify/refresh", async (req, res) => {
+  try {
+    ensureSpotifyCredentials();
+    const { refreshToken } = req.body ?? {};
+    if (!refreshToken) {
+      return res.status(400).json({ error: "refreshToken is required" });
+    }
+
+    const params = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken
+    });
+
+    const response = await fetch("https://accounts.spotify.com/api/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${Buffer.from(
+          `${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`
+        ).toString("base64")}`
+      },
+      body: params.toString()
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      const message = data?.error_description || data?.error || "Spotify token refresh failed";
+      return res.status(response.status || 500).json({
+        error: message,
+        details: data
+      });
+    }
+
+    res.json(data);
+  } catch (error) {
+    console.error("Spotify refresh error:", error);
+    res.status(error.status || 500).json({
+      error: error.message || "Spotify refresh failed",
+      details: error.details ?? null
+    });
   }
 });
 

--- a/config.html
+++ b/config.html
@@ -11,14 +11,7 @@
   <nav id="nav"></nav>
   <div id="credentials">
     <h2>Spotify Zugangsdaten</h2>
-    <label>
-      Client ID:
-      <input type="text" id="clientId" placeholder="Client ID">
-    </label>
-    <label>
-      Client Secret:
-      <input type="text" id="clientSecret" placeholder="Client Secret">
-    </label>
+    <p id="spotifyStatus">Lade Status...</p>
     <label>
       OpenAPI Token:
       <input type="text" id="openApiToken" placeholder="Token">
@@ -29,17 +22,37 @@
     </label>
     <button onclick="saveCredentials()">Speichern</button>
   </div>
+  <script src="spotify.js"></script>
   <script src="pages.js"></script>
   <script src="navigation.js"></script>
   <script>
     buildNavigation('nav');
-    document.getElementById('clientId').value = localStorage.getItem('CLIENT_ID') || '';
-    document.getElementById('clientSecret').value = localStorage.getItem('CLIENT_SECRET') || '';
     document.getElementById('openApiToken').value = localStorage.getItem('OPENAPI_TOKEN') || '';
     document.getElementById('riotApiKey').value = localStorage.getItem('RIOT_API_KEY') || '';
+    const spotifyStatus = document.getElementById('spotifyStatus');
+
+    async function updateSpotifyStatus() {
+      spotifyStatus.textContent = 'Lade Status...';
+      try {
+        const config = await spotifyApi.getConfig();
+        if (!config?.clientId) {
+          spotifyStatus.textContent = '❌ Keine Spotify-Client-ID hinterlegt (.env).';
+          return;
+        }
+        if (!config?.hasClientSecret) {
+          spotifyStatus.textContent = '⚠️ Client-ID vorhanden, aber kein Client-Secret in der .env.';
+          return;
+        }
+        spotifyStatus.textContent = '✅ Spotify-Zugangsdaten werden serverseitig aus der .env geladen.';
+      } catch (err) {
+        console.error('Spotify Status Fehler:', err);
+        spotifyStatus.textContent = '❌ Status konnte nicht geladen werden. Siehe Konsole.';
+      }
+    }
+
+    updateSpotifyStatus();
+
     function saveCredentials() {
-      localStorage.setItem('CLIENT_ID', document.getElementById('clientId').value);
-      localStorage.setItem('CLIENT_SECRET', document.getElementById('clientSecret').value);
       localStorage.setItem('OPENAPI_TOKEN', document.getElementById('openApiToken').value);
       localStorage.setItem('RIOT_API_KEY', document.getElementById('riotApiKey').value);
       alert('Credentials gespeichert!');

--- a/gameModeDigital.html
+++ b/gameModeDigital.html
@@ -562,6 +562,7 @@
     let spotifyTokenExpiry = 0;
     let availableSpotifyDevices = [];
     let selectedSpotifyDeviceId = null;
+    let spotifyServerConfig = null;
 
     function loadSpotifyAuthFromStorage() {
       spotifyAccessToken = localStorage.getItem(SPOTIFY_ACCESS_STORAGE_KEY);
@@ -594,11 +595,16 @@
       localStorage.removeItem(SPOTIFY_EXPIRY_STORAGE_KEY);
     }
 
-    function getSpotifyCredentials() {
-      return {
-        clientId: localStorage.getItem('CLIENT_ID'),
-        clientSecret: localStorage.getItem('CLIENT_SECRET')
-      };
+    async function loadSpotifyServerConfig() {
+      if (spotifyServerConfig) return spotifyServerConfig;
+      try {
+        spotifyServerConfig = await spotifyApi.getConfig();
+        return spotifyServerConfig;
+      } catch (err) {
+        console.error('Spotify Konfigurationsfehler:', err);
+        alert('Spotify-Konfiguration konnte nicht geladen werden. Bitte prüfe die Server-Logs.');
+        return null;
+      }
     }
 
     function isSpotifyConnected() {
@@ -788,17 +794,21 @@
       return Array.from(randomValues, (val) => charset[val % charset.length]).join('');
     }
 
-    function startSpotifyLogin() {
-      const { clientId, clientSecret } = getSpotifyCredentials();
-      if (!clientId || !clientSecret) {
-        alert('Bitte hinterlege Client ID und Client Secret in den Konfigurationen, bevor du Spotify verbindest.');
+    async function startSpotifyLogin() {
+      const config = await loadSpotifyServerConfig();
+      if (!config?.clientId) {
+        alert('Spotify-Client-ID ist nicht konfiguriert. Bitte hinterlege sie in der Server-Konfiguration.');
+        return;
+      }
+      if (!config?.hasClientSecret) {
+        alert('Spotify-Client-Secret ist nicht konfiguriert. Bitte ergänze die Server-Konfiguration.');
         return;
       }
       const state = createRandomState(16);
       sessionStorage.setItem(SPOTIFY_AUTH_STATE_KEY, state);
       const authUrl = new URL('https://accounts.spotify.com/authorize');
       authUrl.searchParams.set('response_type', 'code');
-      authUrl.searchParams.set('client_id', clientId);
+      authUrl.searchParams.set('client_id', config.clientId);
       authUrl.searchParams.set('scope', SPOTIFY_SCOPES.join(' '));
       authUrl.searchParams.set('redirect_uri', SPOTIFY_REDIRECT_URI);
       authUrl.searchParams.set('state', state);
@@ -807,66 +817,40 @@
     }
 
     async function exchangeSpotifyCode(code) {
-      const { clientId, clientSecret } = getSpotifyCredentials();
-      if (!clientId || !clientSecret) {
-        alert('Spotify-Anmeldung fehlgeschlagen: Client ID oder Secret fehlen.');
+      const config = await loadSpotifyServerConfig();
+      if (!config?.clientId || !config?.hasClientSecret) {
+        alert('Spotify-Anmeldung fehlgeschlagen: Server-Konfiguration unvollständig.');
         return false;
       }
-      const body = new URLSearchParams({
-        grant_type: 'authorization_code',
-        code,
-        redirect_uri: SPOTIFY_REDIRECT_URI
-      });
-      const resp = await fetch('https://accounts.spotify.com/api/token', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Authorization': 'Basic ' + btoa(`${clientId}:${clientSecret}`)
-        },
-        body: body.toString()
-      });
-      const data = await resp.json();
-      if (!resp.ok) {
-        console.error('Spotify Token Fehler:', data);
+      try {
+        const data = await spotifyApi.exchangeCode(code, SPOTIFY_REDIRECT_URI);
+        saveSpotifyTokens(data);
+        return true;
+      } catch (err) {
+        console.error('Spotify Token Fehler:', err?.details || err);
         alert('Spotify-Anmeldung fehlgeschlagen. Details siehe Konsole.');
         return false;
       }
-      saveSpotifyTokens(data);
-      return true;
     }
 
     async function refreshSpotifyAccessToken() {
       if (!spotifyRefreshToken) return false;
-      const { clientId, clientSecret } = getSpotifyCredentials();
-      if (!clientId || !clientSecret) return false;
+      const config = await loadSpotifyServerConfig();
+      if (!config?.hasClientSecret) return false;
 
-      const body = new URLSearchParams({
-        grant_type: 'refresh_token',
-        refresh_token: spotifyRefreshToken
-      });
-
-      const resp = await fetch('https://accounts.spotify.com/api/token', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Authorization': 'Basic ' + btoa(`${clientId}:${clientSecret}`)
-        },
-        body: body.toString()
-      });
-
-      const data = await resp.json();
-      if (!resp.ok) {
-        console.error('Spotify Refresh Fehler:', data);
+      try {
+        const data = await spotifyApi.refreshToken(spotifyRefreshToken);
+        saveSpotifyTokens({
+          access_token: data.access_token,
+          refresh_token: data.refresh_token || spotifyRefreshToken,
+          expires_in: data.expires_in
+        });
+        return true;
+      } catch (err) {
+        console.error('Spotify Refresh Fehler:', err?.details || err);
         clearSpotifyAuth();
         return false;
       }
-
-      saveSpotifyTokens({
-        access_token: data.access_token,
-        refresh_token: data.refresh_token || spotifyRefreshToken,
-        expires_in: data.expires_in
-      });
-      return true;
     }
 
     async function ensureSpotifyAccessToken() {
@@ -1097,9 +1081,10 @@
 
     async function fetchPlaylistTracks(playlistUrl) {
       const playlistId = extractPlaylistId(playlistUrl);
-      const spotifyToken = await getSpotifyAccessToken();
-      const playlistTracks = await getPlaylistTracks(playlistId, spotifyToken);
-      return playlistTracks;
+      if (!playlistId) {
+        throw new Error('Ungültige Playlist-URL');
+      }
+      return spotifyApi.fetchPlaylistTracks(playlistId);
     }
 
     function randomTrack() {

--- a/generator.html
+++ b/generator.html
@@ -48,8 +48,12 @@
         }
 
         const playlistId = extractPlaylistId(playlistUrl);
-        const spotifyToken = await getSpotifyAccessToken();
-        const tracks = await getPlaylistTracks(playlistId, spotifyToken);
+        if (!playlistId) {
+          log("❌ Ungültige Playlist-URL.");
+          return;
+        }
+
+        const tracks = await spotifyApi.fetchPlaylistTracks(playlistId);
 
         let aiInfos = [];
         if (useAI) {

--- a/spotify.js
+++ b/spotify.js
@@ -1,73 +1,78 @@
-function extractPlaylistId(url) {
-  const match = url.match(/playlist\/([a-zA-Z0-9]+)/);
-  return match ? match[1] : null;
-}
+(() => {
+  const API_BASE = "/api/spotify";
+  let configPromise = null;
 
-async function getSpotifyAccessToken() {
-  console.log("Hole Spotify Access Token...");
-  const CLIENT_ID = localStorage.getItem("CLIENT_ID");
-  const CLIENT_SECRET = localStorage.getItem("CLIENT_SECRET");
-  const resp = await fetch("https://accounts.spotify.com/api/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      "Authorization": "Basic " + btoa(CLIENT_ID + ":" + CLIENT_SECRET)
-    },
-    body: "grant_type=client_credentials"
-  });
-  const data = await resp.json();
-  if (!resp.ok) throw new Error("Spotify Token Fehler: " + JSON.stringify(data));
-  try {
-    log("Spotify Token erhalten");
-  } catch {
-    console.log("Spotify Token erhalten");
+  async function fetchFromBackend(path, options = {}) {
+    const headers = { ...(options.headers || {}) };
+    const hasBody = options.body !== undefined && options.body !== null;
+    if (hasBody && !headers["Content-Type"]) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const requestInit = {
+      credentials: options.credentials ?? "same-origin",
+      headers,
+      method: options.method ?? (hasBody ? "POST" : "GET"),
+      body: hasBody ? JSON.stringify(options.body) : undefined
+    };
+
+    const response = await fetch(`${API_BASE}${path}`, requestInit);
+    let data = null;
+    try {
+      data = await response.json();
+    } catch (error) {
+      data = null;
+    }
+
+    if (!response.ok) {
+      const message = data?.error || data?.message || "Unbekannter Spotify-Fehler";
+      const err = new Error(message);
+      err.status = response.status;
+      err.details = data;
+      throw err;
+    }
+
+    return data;
   }
-  return data.access_token;
-}
 
-async function getPlaylistTracks(playlistId, token) {
-  try {
-    log("Lade Playlist-Daten...");
-  } catch {
-    console.log("Lade Playlist-Daten...");
+  async function getSpotifyConfig() {
+    if (!configPromise) {
+      configPromise = fetchFromBackend("/config");
+    }
+    return configPromise;
   }
 
-  let url = `https://api.spotify.com/v1/playlists/${playlistId}/tracks?limit=100`;
-  let tracks = [];
-
-  while (url) {
-    const resp = await fetch(url, {
-      headers: {
-        Authorization: "Bearer " + token
-      }
+  async function exchangeSpotifyCode(code, redirectUri) {
+    return fetchFromBackend("/token", {
+      method: "POST",
+      body: { code, redirectUri }
     });
-    const data = await resp.json();
-    if (!resp.ok) throw new Error("Spotify Tracks Fehler: " + JSON.stringify(data));
+  }
 
-    data.items.forEach(item => {
-      if (item.track) {
-        const album = item.track.album || {};
-        const releaseDate = album.release_date || "";
-        const year = releaseDate ? releaseDate.slice(0, 4) : "unknown";
-
-        tracks.push({
-          name: item.track.name,
-          artist: item.track.artists.map(a => a.name).join(", "),
-          url: item.track.external_urls.spotify,
-          cover: album.images?.[0]?.url || "",
-          year: releaseDate,
-          preview: item.track.preview_url || null
-        });
-      }
+  async function refreshSpotifyToken(refreshToken) {
+    return fetchFromBackend("/refresh", {
+      method: "POST",
+      body: { refreshToken }
     });
-
-    url = data.next;
   }
 
-  try {
-    log(`Gefundene Songs: ${tracks.length}`);
-  } catch {
-    console.log(`Gefundene Songs: ${tracks.length}`);
+  async function fetchSpotifyPlaylistTracks(playlistId) {
+    const result = await fetchFromBackend(`/playlists/${encodeURIComponent(playlistId)}/tracks`);
+    return result?.tracks ?? [];
   }
-  return tracks;
-}
+
+  function extractPlaylistId(url) {
+    const match = url?.match(/playlist\/([a-zA-Z0-9]+)/);
+    return match ? match[1] : null;
+  }
+
+  window.spotifyApi = {
+    getConfig: getSpotifyConfig,
+    exchangeCode: exchangeSpotifyCode,
+    refreshToken: refreshSpotifyToken,
+    fetchPlaylistTracks: fetchSpotifyPlaylistTracks
+  };
+
+  window.extractPlaylistId = extractPlaylistId;
+  window.getPlaylistTracks = fetchSpotifyPlaylistTracks;
+})();


### PR DESCRIPTION
## Summary
- load environment variables from the local .env file before bootstrapping the Node backend and cache Spotify client credentials tokens
- expose backend endpoints for Spotify configuration, playlist lookup, and OAuth token exchange/refresh while proxying playlist requests through the server
- refactor spotify.js plus generator and gameModeDigital flows to call the backend helper API instead of hitting Spotify directly and update the configuration page to reflect server-managed credentials

## Testing
- npm install dotenv@^16 --save *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68db92d5833c832f96f24a0af3d35c4c