### PR TITLE
Pass Spotify and OpenAI secrets into backend container

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ labels:
 
 - **Lokale Tests**: Mit `docker compose up` ohne `-d` starten, um Logs direkt im Terminal zu verfolgen.
 - **Konfigurationsänderungen**: Nach Anpassungen an Dockerfiles oder `docker-compose.yml` den Stack mit `docker compose up -d --build` neu deployen.
-- **Backend-Variablen**: `PORT` und `DATASET_PATH` lassen sich via `.env` überschreiben.
+- **Backend-Variablen**: `PORT` und `DATASET_PATH` lassen sich via `.env` überschreiben. Zusätzlich werden `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `OPENAI_API_KEY` und `OPENAI_DEFAULT_MODEL` automatisch aus der `.env` in den Backend-Container durchgereicht.
 - **Fehlersuche**: `docker compose exec backend sh` öffnet eine Shell im Backend-Container.
 
 Für Erweiterungen (z. B. zusätzliche Services, Worker, Cronjobs) empfiehlt sich, eigene Netzwerke oder Compose-Profile zu definieren. Dokumentiere neue Umgebungsvariablen stets in `.env.example`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       - PORT=${BACKEND_PORT:-3000}
       - DATASET_PATH=${BACKEND_DATASET_PATH:-/app/dataset/characters.jsonl}
       - API_TOKEN=${BACKEND_API_TOKEN:-}
+      - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
+      - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - OPENAI_DEFAULT_MODEL=${OPENAI_DEFAULT_MODEL:-gpt-4o-mini}
     volumes:
       - ./anime-dataset/dataset:/app/dataset
     networks:


### PR DESCRIPTION
## Summary
- forward Spotify and OpenAI configuration from the top-level .env file into the backend service
- document the automatic propagation of these secrets in the deployment guide

## Testing
- not run (configuration/documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68dba303b8e8832f92d1005ddfb7fc29