### PR TITLE
Add architecture documentation and repository overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ Diese Dokumentation beschreibt, wie das Projekt mithilfe von Docker-Containern b
 
 > **Hinweis:** Alle Riot-/Arena-Tools, der Spotify Play Screen, der Playlist-zu-QR-Generator sowie Debug- und Dataset-Verwaltungen wurden entfernt. Übrig bleiben der Digital Mode, die Kostenkalkulation und der Anime Rätsel Chat.
 
+## Repository-Struktur
+
+Das Repository ist in mehrere Domänen gegliedert:
+
+- **Frontend** (`projects/dev-portal/`): zentrales Web-Frontend für Nutzeroberflächen.
+- **Backend** (`projects/dev-backend/`): gemeinsamer API-Layer für Authentifizierung sowie datengetriebene Funktionen.
+- **Services** (`projects/services/`): spezialisierte Fachservices wie Arena, Hitster, Anime und Planning.
+- **Infra** (`infra/`): Infrastrukturdefinitionen, Deployment-Skripte und IaC-Artefakte.
+
+Eine vollständige Zielstruktur inklusive Naming-Konventionen und README-Template für Services ist in [`docs/architecture.md`](docs/architecture.md) dokumentiert.
+
 ## Verzeichnisstruktur
 
 - `anime-dataset/`: Node.js-Backend-Service für Spotify-/OpenAI-Bridging sowie den Anime-Datensatz (ohne Frontend-Verwaltung).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,71 @@
+# Architekturübersicht
+
+Diese Architekturübersicht beschreibt die angestrebte Zielstruktur des Repositories und legt verbindliche Konventionen für die Ablage von Quellcode, Assets und Dokumentation fest.
+
+## Zielstruktur
+
+```
+/
+├── docs/
+│   ├── architecture.md           # Architekturleitfaden (dieses Dokument)
+│   └── service-inventory.md      # Übersicht vorhandener Services
+├── projects/
+│   ├── dev-portal/               # Zentrales Frontend (Marketing, Dashboards)
+│   ├── dev-backend/              # Gemeinsames Backend für Auth, Nutzer- und Tooling-APIs
+│   └── services/
+│       ├── arena/                # Arena-Service (Matchmaking & Statistiken)
+│       ├── hitster/              # Musik-Quiz-Service
+│       ├── anime/                # Anime-Rätsel- und Dataset-Service
+│       └── planning/             # Projekt- und Ressourcenplanung
+├── infra/                        # Infrastruktur, IaC, Deployment-Skripte
+└── scripts/                      # Wiederverwendbare Hilfsskripte (CI, Wartung)
+```
+
+## Naming-Konventionen
+
+- **Verzeichnisse**: Kleinbuchstaben mit Bindestrich (`kebab-case`), z. B. `dev-portal`, `data-sync-worker`.
+- **Dateien**:
+  - HTML-Dateien: `feature-name.page.html`
+  - CSS-Dateien: `feature-name.styles.css`
+  - JavaScript-Module: `feature-name.module.js` oder `*.service.js` für Services.
+  - Tests: `*.spec.js` für Unit-Tests, `*.e2e.js` für End-to-End-Tests.
+- **Assets**: Bilder als `*.webp` oder `*.svg`. Dateinamen beschreibend und in `kebab-case`, z. B. `hero-banner.webp`.
+- **Konfigurationsdateien**: `*.config.json` oder `*.config.js` mit Präfix für den jeweiligen Service (`arena.config.json`).
+
+## Erwartete Inhalte je Ordner
+
+| Ordner                                   | Pflichtinhalte                                                                                  | Optionale Inhalte                                  |
+|------------------------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| `projects/dev-portal/`                   | `public/` (statische Assets), `src/` (Frontend-Quellcode), `package.json`, `README.md`          | `tests/`, `storybook/`, `docs/`                     |
+| `projects/dev-backend/`                  | `src/`, `tests/`, `package.json` oder `requirements.txt`, `README.md`                           | `migrations/`, `docs/`                              |
+| `projects/services/<service>/`           | `src/`, `public/`, `tests/`, `README.md` (siehe Template), `package.json`/`requirements.txt`    | `docs/`, `infrastructure/`, `local/`                |
+| `projects/services/<service>/src/`       | Fachlogik, Controller, Komponenten gemäß Technologiestack                                       | `__mocks__/`, `__fixtures__/`                       |
+| `projects/services/<service>/public/`    | Statische Assets (Icons, Fonts, Bilder)                                                         | `locales/` für Übersetzungen                        |
+| `projects/services/<service>/tests/`     | Unit-/Integrationstests, Testdaten                                                              | `e2e/` für End-to-End-Tests                         |
+| `infra/`                                 | IaC-Definitionen (`terraform/`, `pulumi/`), Compose-Files, Deployment-Pipelines                  | `monitoring/`, `observability/`                     |
+| `scripts/`                               | Wiederverwendbare Skripte, die dienstübergreifend genutzt werden (Shell, Node, Python)          | `README.md` mit Anwendungsbeispielen                |
+
+## Template für Service-READMEs
+
+Jeder Service innerhalb von `projects/services/` muss eine `README.md` enthalten, die sich an folgendem Template orientiert:
+
+```markdown
+# <Service-Name>
+
+## Zweck
+- Kurzbeschreibung des Funktionsumfangs und der Zielnutzer:innen.
+- Auflistung wichtiger Domänenbegriffe oder Geschäftsprozesse.
+
+## Externe Abhängigkeiten
+- APIs (z. B. Spotify, OpenAI) mit Links zur Dokumentation.
+- Datenbanken oder Queues (z. B. PostgreSQL, Redis) inklusive Verbindungsdetails.
+- Interne Services, auf die zugegriffen wird (z. B. `dev-backend`, `infra/monitoring`).
+
+## Deploy-Hinweise
+- Build- bzw. Startbefehle (`npm run build`, `docker compose up`, etc.).
+- Erwartete Umgebungsvariablen samt Kurzbeschreibung.
+- Besondere Migrations- oder Seed-Schritte.
+- Hinweise zur Observability (Monitoring, Logging, Alerts).
+```
+
+Die Struktur wird regelmäßig überprüft und bei neuen Services oder Technologien erweitert. Änderungen an den Konventionen sind in Pull Requests zu dokumentieren.


### PR DESCRIPTION
## Summary
- add a new architecture guide describing the target repository structure, naming conventions, and service README template
- extend the root README with a Repository-Struktur section referencing the architecture guide and summarising the project domains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf0936e14832fb715d4ad563ae280