### PR TITLE
Render nginx config from template during frontend build

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,15 +1,32 @@
 # syntax=docker/dockerfile:1
 FROM nginx:1.27-alpine
 
-RUN mkdir -p /var/www/certbot
+ARG DEV_SERVER_NAME=dev.localhost
+ARG WWW_SERVER_NAME=www.localhost
 
-# Copy nginx configuration with backend proxy setup
-COPY docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+ENV DEV_SERVER_NAME=${DEV_SERVER_NAME} \
+    WWW_SERVER_NAME=${WWW_SERVER_NAME}
+
+RUN apk add --no-cache bash \
+    && mkdir -p /var/www/certbot /opt/app
+
+WORKDIR /opt/app
+
+COPY scripts/render-nginx-config.sh scripts/render-nginx-config.sh
+COPY docker/nginx/templates docker/nginx/templates
+COPY docker/nginx/entrypoint.sh docker/nginx/entrypoint.sh
+
+RUN chmod +x scripts/render-nginx-config.sh docker/nginx/entrypoint.sh
 
 # Copy static assets into nginx document root
 COPY --chown=nginx:nginx projects/dev-portal /usr/share/nginx/html/dev-portal
 COPY --chown=nginx:nginx projects/services /usr/share/nginx/html/services
 
+RUN scripts/render-nginx-config.sh "$DEV_SERVER_NAME" "$WWW_SERVER_NAME" \
+    && cp docker/nginx/default.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=3s CMD wget -q -O- http://localhost/ >/dev/null 2>&1 || exit 1
+
+ENTRYPOINT ["/opt/app/docker/nginx/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,11 +40,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.frontend
+      args:
+        DEV_SERVER_NAME: ${DEV_SERVER_NAME:-dev.localhost}
+        WWW_SERVER_NAME: ${WWW_SERVER_NAME:-www.localhost}
     image: behamot007/anime-frontend:latest
     depends_on:
       - backend
     environment:
       - BACKEND_API_BASE=${FRONTEND_BACKEND_API_BASE:-http://backend:3000}
+      - DEV_SERVER_NAME=${DEV_SERVER_NAME:-dev.localhost}
+      - WWW_SERVER_NAME=${WWW_SERVER_NAME:-www.localhost}
     volumes:
       - ./server/certbot/www:/var/www/certbot
     ports:

--- a/docker/nginx/entrypoint.sh
+++ b/docker/nginx/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+APP_DIR="/opt/app"
+RENDER_SCRIPT="$APP_DIR/scripts/render-nginx-config.sh"
+OUTPUT_FILE="$APP_DIR/docker/nginx/default.conf"
+
+DEV_SERVER_NAME="${DEV_SERVER_NAME:-dev.localhost}"
+WWW_SERVER_NAME="${WWW_SERVER_NAME:-www.localhost}"
+
+if [ ! -x "$RENDER_SCRIPT" ]; then
+  echo "Render script $RENDER_SCRIPT not found or not executable" >&2
+  exit 1
+fi
+
+cd "$APP_DIR"
+"$RENDER_SCRIPT" "$DEV_SERVER_NAME" "$WWW_SERVER_NAME"
+cp "$OUTPUT_FILE" /etc/nginx/conf.d/default.conf
+
+exec nginx -g "daemon off;"


### PR DESCRIPTION
## Summary
- copy the nginx config rendering script and template into the frontend image
- render the config during build with default hostnames and add an entrypoint to re-render at runtime
- pass DEV_SERVER_NAME and WWW_SERVER_NAME through docker-compose as build args and environment variables

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcfd942d84832fb559cded5dab0587