### PR TITLE
Add placeholder www site and extend nginx configuration

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -20,6 +20,7 @@ RUN chmod +x scripts/render-nginx-config.sh docker/nginx/entrypoint.sh
 
 # Copy static assets into nginx document root
 COPY --chown=nginx:nginx projects/sites/dev /usr/share/nginx/html/dev
+COPY --chown=nginx:nginx projects/sites/www /usr/share/nginx/html/www
 
 RUN scripts/render-nginx-config.sh "$DEV_SERVER_NAME" "$WWW_SERVER_NAME" \
     && cp docker/nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/docker/nginx/templates/dev_www.conf.tpl
+++ b/docker/nginx/templates/dev_www.conf.tpl
@@ -37,6 +37,10 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript application/octet-stream image/svg+xml;
 
+    location /assets/ {
+        try_files $uri $uri/ =404;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/projects/sites/www/index.html
+++ b/projects/sites/www/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BehamotVT – Coming Soon</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="placeholder">
+    <h1>BehamotVT – Coming Soon</h1>
+    <p>Diese Seite befindet sich noch im Aufbau. Schau bald wieder vorbei!</p>
+  </main>
+</body>
+</html>

--- a/projects/sites/www/styles.css
+++ b/projects/sites/www/styles.css
@@ -1,0 +1,38 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.4), transparent 55%),
+    radial-gradient(circle at bottom, rgba(14, 116, 144, 0.45), transparent 60%),
+    #0f172a;
+}
+
+.placeholder {
+  text-align: center;
+  padding: 3rem 2rem;
+  border-radius: 1.5rem;
+  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.45);
+}
+
+.placeholder h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.5rem, 5vw, 3.25rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.placeholder p {
+  margin: 0;
+  font-size: clamp(1rem, 2.5vw, 1.25rem);
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary
- add a placeholder www site with basic styling assets
- extend the nginx template with a www server block that serves static assets
- include the new www site in the frontend Docker image build

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd00661534832faee6792f1f0c407a