### PR TITLE
Add startup automation script for server deployment

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -7,3 +7,31 @@ scripts/render-nginx-config.sh dev.behamot.de www.behamot.de
 ```
 
 Der erste Parameter steht für die Entwicklungs-Domain (inklusive Proxy-Pass auf `/api`), der zweite Parameter für die öffentliche Domain. Das Skript schreibt das Ergebnis nach `docker/nginx/default.conf` und sollte immer vor einem Deployment ausgeführt werden. Die GitHub-Deploy-Pipeline ruft das Skript automatisch mit den Domains `dev.behamot.de` und `www.behamot.de` auf.
+
+## Automatisiertes Startup-Skript
+
+Für Server, auf denen ein Host-Nginx als Reverse Proxy eingesetzt wird, steht mit `server/scripts/startup.sh` ein ausführbares Startup-Skript zur Verfügung. Es kombiniert sämtliche manuellen Schritte in einem automatisierten Ablauf:
+
+1. stellt sicher, dass `.env` aus der Vorlage existiert,
+2. rendert die Container-nginx-Konfiguration mit den gewünschten Domains,
+3. erzeugt ein `docker-compose.override.yml`, das den Backend-Port auf `127.0.0.1:${BACKEND_PORT}` bindet,
+4. baut und startet den Docker-Compose-Stack (`docker compose up -d --build`),
+5. schreibt optional eine Host-Nginx-Konfiguration inklusive ACME-Weiterleitung und `/api`-Proxy und lädt Nginx neu.
+
+Standardmäßig richtet das Skript die Domains `dev.behamot.de` und `www.behamot.de` ein. Über Umgebungsvariablen lassen sich sämtliche Pfade und Hostnamen anpassen:
+
+```bash
+sudo DEV_DOMAIN=dev.example.com \
+     WWW_DOMAIN=www.example.com \
+     FRONTEND_PORT=8080 \
+     BACKEND_PORT=3000 \
+     server/scripts/startup.sh
+```
+
+Für Systeme ohne Host-Nginx kann die Generierung der Host-Konfiguration deaktiviert werden:
+
+```bash
+GENERATE_HOST_NGINX=false server/scripts/startup.sh
+```
+
+Das Skript erwartet funktionsfähige Installationen von Docker (inkl. Compose-Plugin) und Nginx. Vor dem Reload wird automatisch `nginx -t` aufgerufen. Bei erfolgreichem Lauf stehen die Container auf den gewünschten Subdomains bereit.

--- a/server/scripts/startup.sh
+++ b/server/scripts/startup.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+#
+# Startup-Automation für den Toolkit-Stack.
+#
+# Dieses Skript verbindet die einzelnen Deployment-Schritte aus der Dokumentation
+# zu einem wiederholbaren Ablauf:
+#   * lokale .env-Datei sicherstellen
+#   * Nginx-Konfiguration innerhalb des Frontend-Containers rendern
+#   * Backend-Port auf den Host binden (damit der Host-Nginx /api-Anfragen weiterleiten kann)
+#   * Docker-Compose-Stack bauen und starten
+#   * (optional) Host-Nginx als Reverse Proxy konfigurieren und neu laden
+#
+# Die wichtigsten Parameter können über Umgebungsvariablen gesteuert werden. Alle
+# Variablen besitzen sinnvolle Defaults für das Live-Setup auf behamot.de.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DEV_DOMAIN=${DEV_DOMAIN:-dev.behamot.de}
+WWW_DOMAIN=${WWW_DOMAIN:-www.behamot.de}
+FRONTEND_PORT=${FRONTEND_PORT:-8080}
+BACKEND_PORT=${BACKEND_PORT:-3000}
+BACKEND_BIND_ADDRESS=${BACKEND_BIND_ADDRESS:-127.0.0.1}
+CERTBOT_WEBROOT=${CERTBOT_WEBROOT:-/var/www/certbot}
+LE_LIVE_ROOT=${LE_LIVE_ROOT:-/etc/letsencrypt/live}
+DEV_CERT_NAME=${DEV_CERT_NAME:-$DEV_DOMAIN}
+WWW_CERT_NAME=${WWW_CERT_NAME:-$WWW_DOMAIN}
+NGINX_CONFIG_PATH=${NGINX_CONFIG_PATH:-/etc/nginx/sites-available/behamot.conf}
+NGINX_ENABLED_PATH=${NGINX_ENABLED_PATH:-/etc/nginx/sites-enabled/behamot.conf}
+GENERATE_HOST_NGINX=${GENERATE_HOST_NGINX:-true}
+DOCKER_COMPOSE_OVERRIDE=${DOCKER_COMPOSE_OVERRIDE:-docker-compose.override.yml}
+
+log() {
+  printf '[startup] %s\n' "$*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Fehlende Abhängigkeit: $1" >&2
+    exit 1
+  fi
+}
+
+log "Prüfe Abhängigkeiten"
+require_cmd docker
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Docker Compose Plugin nicht gefunden (docker compose)." >&2
+  exit 1
+fi
+
+if [[ "${GENERATE_HOST_NGINX}" == "true" ]]; then
+  require_cmd nginx
+fi
+
+log ".env-Datei prüfen"
+if [[ -x "${REPO_ROOT}/scripts/ensure-env.sh" ]]; then
+  (cd "${REPO_ROOT}" && ./scripts/ensure-env.sh)
+else
+  log "Warnung: ensure-env.sh nicht gefunden oder nicht ausführbar"
+fi
+
+log "Render Nginx-Konfiguration im Frontend-Container"
+(cd "${REPO_ROOT}" && ./scripts/render-nginx-config.sh "$DEV_DOMAIN" "$WWW_DOMAIN")
+
+log "Erzeuge docker-compose-Override für Backend-Port"
+cat > "${REPO_ROOT}/${DOCKER_COMPOSE_OVERRIDE}" <<EOF_OVERRIDE
+# Automatisch erzeugt durch server/scripts/startup.sh am $(date -Iseconds)
+services:
+  backend:
+    ports:
+      - "${BACKEND_BIND_ADDRESS}:${BACKEND_PORT}:${BACKEND_PORT}"
+EOF_OVERRIDE
+
+log "Starte Docker Compose Stack"
+export DEV_SERVER_NAME="$DEV_DOMAIN"
+export WWW_SERVER_NAME="$WWW_DOMAIN"
+export BACKEND_PORT
+(cd "${REPO_ROOT}" && docker compose up -d --build)
+
+if [[ "${GENERATE_HOST_NGINX}" == "true" ]]; then
+  log "Bereite Host-Nginx-Konfiguration vor"
+  mkdir -p "$(dirname "${NGINX_CONFIG_PATH}")"
+  mkdir -p "$(dirname "${NGINX_ENABLED_PATH}")"
+  mkdir -p "$CERTBOT_WEBROOT"
+
+  cat > "$NGINX_CONFIG_PATH" <<EOF_NGINX
+# Automatisch erzeugt durch server/scripts/startup.sh am $(date -Iseconds)
+# leitet behamot.de Domains auf die Docker-Services weiter
+
+upstream behamot_frontend {
+    server 127.0.0.1:${FRONTEND_PORT};
+}
+
+upstream behamot_backend {
+    server ${BACKEND_BIND_ADDRESS}:${BACKEND_PORT};
+}
+
+map \$http_upgrade \$connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${DEV_DOMAIN} ${WWW_DOMAIN};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root ${CERTBOT_WEBROOT};
+        default_type "text/plain";
+        try_files \$uri =404;
+    }
+
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${DEV_DOMAIN};
+
+    ssl_certificate     ${LE_LIVE_ROOT}/${DEV_CERT_NAME}/fullchain.pem;
+    ssl_certificate_key ${LE_LIVE_ROOT}/${DEV_CERT_NAME}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root ${CERTBOT_WEBROOT};
+        default_type "text/plain";
+        try_files \$uri =404;
+    }
+
+    location / {
+        proxy_pass http://behamot_frontend;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
+    }
+
+    location /api/ {
+        proxy_pass http://behamot_backend;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${WWW_DOMAIN};
+
+    ssl_certificate     ${LE_LIVE_ROOT}/${WWW_CERT_NAME}/fullchain.pem;
+    ssl_certificate_key ${LE_LIVE_ROOT}/${WWW_CERT_NAME}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root ${CERTBOT_WEBROOT};
+        default_type "text/plain";
+        try_files \$uri =404;
+    }
+
+    location / {
+        proxy_pass http://behamot_frontend;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection \$connection_upgrade;
+    }
+}
+EOF_NGINX
+
+  ln -sf "$NGINX_CONFIG_PATH" "$NGINX_ENABLED_PATH"
+
+  log "Teste Nginx-Konfiguration"
+  nginx -t
+
+  if command -v systemctl >/dev/null 2>&1; then
+    log "Starte Nginx-Reload via systemctl"
+    systemctl reload nginx
+  else
+    log "Starte Nginx-Reload via nginx -s reload"
+    nginx -s reload
+  fi
+fi
+
+log "Startup-Prozess abgeschlossen"


### PR DESCRIPTION
## Summary
- add a server-side startup script that automates env preparation, config rendering, docker compose launch, and host nginx setup
- document the new startup workflow and configuration options in the server deployment README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd072292f8832f96eb1b6a2c3eb904