### PR TITLE
Fix Behemoth redirect loop

### DIFF
--- a/projects/sites/www/index.html
+++ b/projects/sites/www/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Behamot – Weiterleitung</title>
-    <meta http-equiv="refresh" content="0; url=./sites/behemoth/" />
-    <link rel="canonical" href="./sites/behemoth/" />
+    <meta http-equiv="refresh" content="0; url=https://www.behamot.de/sites/behemoth/" />
+    <link rel="canonical" href="https://www.behamot.de/sites/behemoth/" />
     <style>
       :root {
         color-scheme: light dark;
@@ -76,7 +76,7 @@
     <main>
       <h1>Weiterleitung zu Behamot</h1>
       <p>Du wirst automatisch zur neuen Startseite weitergeleitet. Sollte dies nicht funktionieren, klicke bitte auf den Button.</p>
-      <a class="redirect-link" href="./sites/behemoth/">
+      <a class="redirect-link" href="https://www.behamot.de/sites/behemoth/">
         Weiter zur Startseite
         <span aria-hidden="true">↗</span>
       </a>


### PR DESCRIPTION
## Summary
- update the Behemoth landing page redirect to use the canonical https://www.behamot.de/sites/behemoth/ URL
- ensure the meta refresh, canonical link, and manual button all point to the new absolute target

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd38fb2d70832f8996749f1a0b8934