### PR TITLE
Create Behamot VTuber showcase one-pager

### DIFF
--- a/projects/sites/www/sites/behemoth/assets/crest-divider.svg
+++ b/projects/sites/www/sites/behemoth/assets/crest-divider.svg
@@ -1,0 +1,12 @@
+<svg width="120" height="48" viewBox="0 0 120 48" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="line" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#8a74d2" stop-opacity="0" />
+      <stop offset="50%" stop-color="#f0c97d" />
+      <stop offset="100%" stop-color="#8a74d2" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <path d="M10 24h100" stroke="url(#line)" stroke-width="2" stroke-linecap="round" />
+  <path d="M60 12 66 24l-6 12-6-12 6-12Z" fill="#f0c97d" opacity="0.9" />
+  <circle cx="60" cy="24" r="6" fill="rgba(23, 18, 36, 0.9)" stroke="#f0c97d" stroke-width="1.5" />
+</svg>

--- a/projects/sites/www/sites/behemoth/assets/expression-calm.svg
+++ b/projects/sites/www/sites/behemoth/assets/expression-calm.svg
@@ -1,0 +1,16 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="45%" r="65%">
+      <stop offset="0%" stop-color="#44367b" />
+      <stop offset="100%" stop-color="#1a1536" />
+    </radialGradient>
+    <linearGradient id="stroke" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f2d89a" />
+      <stop offset="100%" stop-color="#b08544" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="url(#bg)" stroke="url(#stroke)" stroke-width="3" />
+  <path d="M40 48c4-6 10-10 20-10" stroke="#f0c97d" stroke-width="3" stroke-linecap="round" fill="none" />
+  <path d="M80 48c-4-6-10-10-20-10" stroke="#f0c97d" stroke-width="3" stroke-linecap="round" fill="none" />
+  <path d="M44 78c8 10 24 10 32 0" stroke="#f0c97d" stroke-width="3" stroke-linecap="round" fill="none" />
+</svg>

--- a/projects/sites/www/sites/behemoth/assets/expression-charm.svg
+++ b/projects/sites/www/sites/behemoth/assets/expression-charm.svg
@@ -1,0 +1,17 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bgCharm" cx="50%" cy="40%" r="68%">
+      <stop offset="0%" stop-color="#5b3f9a" />
+      <stop offset="100%" stop-color="#1b1638" />
+    </radialGradient>
+    <linearGradient id="strokeCharm" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f7dc9e" />
+      <stop offset="100%" stop-color="#c1924f" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="url(#bgCharm)" stroke="url(#strokeCharm)" stroke-width="3" />
+  <path d="M36 50c6-8 14-12 24-12" stroke="#f4d89d" stroke-width="3" stroke-linecap="round" fill="none" />
+  <path d="M80 56c-4 0-8-4-8-8 0-4 4-8 8-8s8 4 8 8c0 4-4 8-8 8Z" fill="#f4d89d" />
+  <path d="M46 78c8 10 22 12 30 4" stroke="#f4d89d" stroke-width="3" stroke-linecap="round" fill="none" />
+  <path d="M62 82c4 4 10 4 14 0" stroke="#f4d89d" stroke-width="3" stroke-linecap="round" fill="none" />
+</svg>

--- a/projects/sites/www/sites/behemoth/assets/expression-feral.svg
+++ b/projects/sites/www/sites/behemoth/assets/expression-feral.svg
@@ -1,0 +1,17 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bgFeral" cx="50%" cy="35%" r="68%">
+      <stop offset="0%" stop-color="#6f2f5f" />
+      <stop offset="100%" stop-color="#130d26" />
+    </radialGradient>
+    <linearGradient id="strokeFeral" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9dd9e" />
+      <stop offset="100%" stop-color="#a26b2d" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="url(#bgFeral)" stroke="url(#strokeFeral)" stroke-width="3" />
+  <path d="M38 44 58 54" stroke="#f2d488" stroke-width="4" stroke-linecap="round" />
+  <path d="M82 44 62 54" stroke="#f2d488" stroke-width="4" stroke-linecap="round" />
+  <path d="M44 74c8 12 16 16 16 16s8-4 16-16" stroke="#f2d488" stroke-width="4" stroke-linecap="round" fill="none" />
+  <path d="M44 82c8 4 24 4 32 0" stroke="#f2d488" stroke-width="3" stroke-linecap="round" fill="none" />
+</svg>

--- a/projects/sites/www/sites/behemoth/assets/hero-crest.svg
+++ b/projects/sites/www/sites/behemoth/assets/hero-crest.svg
@@ -1,0 +1,29 @@
+<svg width="320" height="320" viewBox="0 0 320 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f0c97d" stop-opacity="0.85" />
+      <stop offset="45%" stop-color="#7c63d2" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#120d26" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="strokeGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f2d38b" />
+      <stop offset="100%" stop-color="#b38a4f" />
+    </linearGradient>
+  </defs>
+  <circle cx="160" cy="160" r="150" fill="url(#glow)" />
+  <path
+    d="M160 34c56 0 102 46 102 102 0 32-16 70-46 113-19 27-39 49-56 66-17-17-37-39-56-66-30-43-46-81-46-113 0-56 46-102 102-102Z"
+    fill="none"
+    stroke="url(#strokeGrad)"
+    stroke-width="4"
+    opacity="0.9"
+  />
+  <circle cx="160" cy="136" r="58" fill="none" stroke="url(#strokeGrad)" stroke-width="2.5" opacity="0.7" />
+  <path
+    d="M160 72c24 0 44 20 44 44 0 12-5 24-14 32l-30-62-30 62c-9-8-14-20-14-32 0-24 20-44 44-44Z"
+    fill="rgba(240, 201, 125, 0.22)"
+    stroke="url(#strokeGrad)"
+    stroke-width="1.5"
+  />
+  <path d="M160 192c20 32 36 54 36 70s-16 26-36 26-36-10-36-26 16-38 36-70Z" fill="rgba(124, 99, 210, 0.35)" />
+</svg>

--- a/projects/sites/www/sites/behemoth/assets/hero-frame.svg
+++ b/projects/sites/www/sites/behemoth/assets/hero-frame.svg
@@ -1,0 +1,40 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2b235c" />
+      <stop offset="100%" stop-color="#14102a" />
+    </linearGradient>
+    <linearGradient id="outline" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f4d99d" />
+      <stop offset="100%" stop-color="#b68847" />
+    </linearGradient>
+    <radialGradient id="halo" cx="50%" cy="30%" r="75%">
+      <stop offset="0%" stop-color="#6f4dd4" stop-opacity="0.65" />
+      <stop offset="70%" stop-color="#241c49" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#120d28" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect x="40" y="40" width="560" height="560" rx="80" fill="url(#panel)" stroke="url(#outline)" stroke-width="6" />
+  <g transform="translate(80 80)">
+    <path
+      d="M240 0c133 0 240 107 240 240v320H0V240C0 107 107 0 240 0Z"
+      fill="url(#halo)"
+      stroke="url(#outline)"
+      stroke-width="4"
+    />
+    <path
+      d="M48 240c0-113 79-204 192-220 113 16 192 107 192 220v240H48V240Z"
+      fill="rgba(13, 9, 26, 0.75)"
+      stroke="url(#outline)"
+      stroke-width="3"
+      opacity="0.9"
+    />
+    <path
+      d="M240 46c98 0 178 80 178 178v216H62V224C62 126 142 46 240 46Z"
+      fill="rgba(52, 41, 101, 0.45)"
+      stroke="rgba(244, 217, 157, 0.4)"
+      stroke-width="2"
+    />
+    <circle cx="240" cy="180" r="110" fill="none" stroke="rgba(244, 217, 157, 0.4)" stroke-width="2" />
+  </g>
+</svg>

--- a/projects/sites/www/sites/behemoth/assets/ornament-gilded.svg
+++ b/projects/sites/www/sites/behemoth/assets/ornament-gilded.svg
@@ -1,0 +1,16 @@
+<svg width="72" height="72" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ornGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f5dca4" />
+      <stop offset="100%" stop-color="#b98b41" />
+    </linearGradient>
+  </defs>
+  <circle cx="36" cy="36" r="32" fill="rgba(53, 42, 102, 0.6)" stroke="url(#ornGradient)" stroke-width="3" />
+  <path
+    d="M36 12 42 30l18 6-18 6-6 18-6-18-18-6 18-6 6-18Z"
+    fill="none"
+    stroke="url(#ornGradient)"
+    stroke-width="3"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/projects/sites/www/sites/behemoth/assets/portrait-silhouette.svg
+++ b/projects/sites/www/sites/behemoth/assets/portrait-silhouette.svg
@@ -1,0 +1,30 @@
+<svg width="400" height="520" viewBox="0 0 400 520" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="silk" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8e5bc" stop-opacity="0.92" />
+      <stop offset="50%" stop-color="#b89a5d" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#473469" stop-opacity="0.8" />
+    </linearGradient>
+    <radialGradient id="shadow" cx="50%" cy="10%" r="90%">
+      <stop offset="0%" stop-color="#fff7dd" stop-opacity="0.8" />
+      <stop offset="40%" stop-color="#d1b277" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#3a2857" stop-opacity="0.2" />
+    </radialGradient>
+  </defs>
+  <path
+    d="M210 36c48 0 88 38 88 98 0 38-12 66-42 96 18 6 30 20 30 38 0 27-28 42-59 40-8 23-21 45-37 60 26 16 37 40 32 66-6 30-32 46-66 46-35 0-60-18-63-50-3-28 12-54 34-68-26-17-42-43-42-78 0-25 11-48 33-64-18-18-27-42-27-72 0-60 40-112 119-112Z"
+    fill="url(#shadow)"
+    opacity="0.9"
+  />
+  <path
+    d="M206 46c-64 0-104 46-104 104 0 34 10 54 36 74-24 16-40 44-40 70 0 42 32 76 76 76 47 0 78-32 82-72 22-4 36-18 36-38 0-16-10-30-30-38 30-30 46-60 46-98 0-60-44-78-102-78Z"
+    fill="url(#silk)"
+    opacity="0.9"
+  />
+  <path
+    d="M250 120c-14 22-38 36-66 36s-52-14-66-36c12-36 40-60 66-60s54 24 66 60Z"
+    fill="#2a1f42"
+    opacity="0.7"
+  />
+  <path d="M178 260c24 4 44-4 56-20-8 36-28 58-54 58s-42-12-52-40c14 8 32 10 50 2Z" fill="#2a1f42" opacity="0.58" />
+</svg>

--- a/projects/sites/www/sites/behemoth/index.html
+++ b/projects/sites/www/sites/behemoth/index.html
@@ -3,186 +3,234 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Behamot – Digitale Tools & Experiences</title>
-    <meta name="description" content="Behamot bündelt digitale Tools, KI-Experimente und Spotify-Automation für unvergessliche Musikabende." />
+    <title>Behamot VTuber – Noble Debut</title>
+    <meta
+      name="description"
+      content="Behamot VTuber – digitale Aristokratie trifft auf Entertainment. Entdecke Streams, Highlights, Lore und Social Links des noblen Behemot."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Manrope:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="./styles.css" />
+    <script defer src="./script.js"></script>
+    <script async src="https://player.twitch.tv/js/embed/v1.js"></script>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   </head>
   <body>
+    <div class="background-lights" aria-hidden="true">
+      <img src="./assets/hero-crest.svg" alt="" class="bg-crest bg-crest--left" />
+      <img src="./assets/hero-crest.svg" alt="" class="bg-crest bg-crest--right" />
+    </div>
     <header class="site-header" data-nav-state="closed">
       <div class="container header__inner">
-        <a class="brand" href="#home" aria-label="Behamot Startseite">
-          <span class="brand__accent" aria-hidden="true">◆</span>
+        <a class="brand" href="#hero" aria-label="Behamot VTuber Start">
+          <img src="./assets/crest-divider.svg" alt="" class="brand__mark" />
           <span class="brand__text">Behamot</span>
+          <span class="brand__role">VTuber</span>
         </a>
-        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primaryNav">
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="siteNav">
           <span class="nav-toggle__label">Menü</span>
           <span class="nav-toggle__icon" aria-hidden="true"></span>
         </button>
-        <nav id="primaryNav" class="primary-nav" aria-label="Hauptnavigation">
-          <a href="#mission">Mission</a>
-          <a href="#features">Features</a>
-          <a href="#use-cases">Use Cases</a>
-          <a href="#contact">Kontakt</a>
+        <nav id="siteNav" class="primary-nav" aria-label="Hauptnavigation">
+          <a href="#hero">Debut</a>
+          <a href="#about">Profil</a>
+          <a href="#stream">Livestream</a>
+          <a href="#socials">Socials</a>
+          <a href="#lore">Lore</a>
         </nav>
       </div>
     </header>
 
-    <main id="home">
-      <section class="hero" aria-labelledby="heroTitle">
+    <main>
+      <section id="hero" class="section hero" aria-labelledby="heroTitle">
         <div class="container hero__inner">
           <div class="hero__content">
-            <span class="eyebrow">Toolkit & Experiences</span>
-            <h1 id="heroTitle">Digitale Spielabende. Automatisiert. Persönlich.</h1>
+            <span class="eyebrow">Noble Debut</span>
+            <h1 id="heroTitle">Behamot – Aristokratischer VTuber aus dem digitalen Hofstaat</h1>
             <p>
-              Behamot verbindet Spotify-Automation, clevere Kostenaufteilung und KI-gestützte Unterhaltung in einem
-              zentralen Toolkit. Für Freundeskreise, Communities und Teams, die schnell loslegen möchten.
+              Willkommen in meinem virtuellen Salon. Ich streame Strategie, Storytelling und kunstvolle Collabs mit einer Prise
+              höfischer Ironie. Komm vorbei, wenn Glanz und Memes aufeinandertreffen.
             </p>
             <div class="hero__actions">
-              <a class="button button--primary" href="#features">Mehr entdecken</a>
-              <a class="button button--ghost" href="#contact">Kontakt aufnehmen</a>
+              <a class="button button--primary" href="https://www.twitch.tv/behamotvt" target="_blank" rel="noreferrer">Zum Twitch-Kanal</a>
+              <a class="button button--ghost" href="#stream">Live ansehen</a>
             </div>
-            <dl class="hero__meta" aria-label="Kennzahlen">
+            <dl class="hero__stats" aria-label="Highlights">
               <div>
-                <dt>3+</dt>
-                <dd>modulare Experiences</dd>
+                <dt>Streams</dt>
+                <dd>Story-RPGs · Strategie · Collabs</dd>
               </div>
               <div>
-                <dt>100%</dt>
-                <dd>steuerbar im Browser</dd>
+                <dt>Signature</dt>
+                <dd>Eleganz, Wortwitz, orchestrale Playlists</dd>
               </div>
               <div>
-                <dt>Ready</dt>
-                <dd>für private Sessions & Events</dd>
+                <dt>Community</dt>
+                <dd>Nobles & Nightingales auf Discord</dd>
               </div>
             </dl>
           </div>
-          <div class="hero__visual" aria-hidden="true">
-            <div class="orb orb--primary"></div>
-            <div class="orb orb--secondary"></div>
-            <div class="screen-mockup">
-              <div class="screen-mockup__header">
-                <span></span><span></span><span></span>
-              </div>
-              <div class="screen-mockup__body">
-                <div class="screen-mockup__badge">Live Toolkit</div>
-                <h2>Digital Mode</h2>
-                <p>Session Setup, Rundenauswahl und Spotify-Steuerung in einem Flow.</p>
-                <ul>
-                  <li>Playlist-Automation</li>
-                  <li>KI-Hinweise</li>
-                  <li>Moderationstools</li>
-                </ul>
+          <div class="hero__visual">
+            <div class="portrait-frame">
+              <img src="./assets/hero-frame.svg" alt="Illustration eines ornamentalen Fensters" class="portrait-frame__base" />
+              <div class="portrait-frame__inner">
+                <img src="./assets/portrait-silhouette.svg" alt="Silhouette von Behamot" class="portrait-frame__character" />
+                <div class="portrait-frame__expressions">
+                  <figure>
+                    <img src="./assets/expression-calm.svg" alt="Calm expression" />
+                    <figcaption>Calm</figcaption>
+                  </figure>
+                  <figure>
+                    <img src="./assets/expression-charm.svg" alt="Charming expression" />
+                    <figcaption>Charm</figcaption>
+                  </figure>
+                  <figure>
+                    <img src="./assets/expression-feral.svg" alt="Fierce expression" />
+                    <figcaption>Feral</figcaption>
+                  </figure>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      <section id="mission" class="section section--alt" aria-labelledby="missionTitle">
-        <div class="container section__inner">
+      <section id="about" class="section section--alt" aria-labelledby="aboutTitle">
+        <div class="container about__inner">
           <div class="section__header">
-            <span class="section__eyebrow">Warum Behamot?</span>
-            <h2 id="missionTitle">Ein Toolkit, viele Anwendungsfälle</h2>
+            <span class="section__eyebrow">VTuber Profil</span>
+            <h2 id="aboutTitle">Ein Aristokrat zwischen Hofball und Hyperspace</h2>
             <p>
-              Von der gemütlichen Wohnzimmer-Session bis zum hybriden Event – Behamot bietet smarte Module, die nahtlos
-              zusammenspielen. Vollständig web-basiert und sofort einsetzbar.
+              Inspiriert von klassischer Noblesse und moderner Sci-Fi. Ich kombiniere barocke Ästhetik mit futuristischen Effekten,
+              spiele komplexe Spiele live und führe meine Community durch narrative Abenteuer.
             </p>
           </div>
-          <div class="feature-grid">
-            <article class="feature-card">
-              <h3>Digital Mode</h3>
-              <p>Steuere Hitster-Runden im Browser, inklusive Scoreboard, Rundenkarten und KI-gestützten Hinweisen.</p>
+          <div class="highlight-grid">
+            <article class="highlight-card">
+              <img src="./assets/ornament-gilded.svg" alt="" aria-hidden="true" />
+              <h3>Signature Mood</h3>
+              <p>Orchestrale Beats, goldene Lichter und ruhige, präzise Moderation – mit spontanen spice Moments.</p>
             </article>
-            <article class="feature-card">
-              <h3>Kostenkalkulation</h3>
-              <p>Erfasse Ausgaben, teile sie automatisch auf und exportiere klare Übersichten für alle Beteiligten.</p>
+            <article class="highlight-card">
+              <img src="./assets/ornament-gilded.svg" alt="" aria-hidden="true" />
+              <h3>Community</h3>
+              <p>Nobles & Nightingales – eine royale Runde für Watch-Partys, Strategiespiele und gemütliche Late-Night-Talks.</p>
             </article>
-            <article class="feature-card">
-              <h3>Anime Rätsel Chat</h3>
-              <p>Starte KI-gestützte Quizrunden mit individuell generierten Hinweisen zu Anime-Charakteren.</p>
-            </article>
-            <article class="feature-card">
-              <h3>Erweiterbar & API-ready</h3>
-              <p>Gemeinsamer Backend-Layer mit Authentifizierung, Streaming-Integrationen und JSON-APIs.</p>
+            <article class="highlight-card">
+              <img src="./assets/ornament-gilded.svg" alt="" aria-hidden="true" />
+              <h3>Stream Setup</h3>
+              <p>VTuber Studio, orchestrale Soundtracks, interaktive Lichtsteuerung und Chat-Etikette mit viel Charme.</p>
             </article>
           </div>
         </div>
       </section>
 
-      <section id="features" class="section" aria-labelledby="featuresTitle">
-        <div class="container section__inner">
+      <section id="stream" class="section" aria-labelledby="streamTitle">
+        <div class="container stream__inner">
           <div class="section__header">
-            <span class="section__eyebrow">Highlights</span>
-            <h2 id="featuresTitle">Alles, was du für deine nächste Session brauchst</h2>
+            <span class="section__eyebrow">Live auf Twitch</span>
+            <h2 id="streamTitle">Direkt vom Thronsaal auf deinen Screen</h2>
+            <p>Schalte live ein oder sieh dir die jüngsten Highlights auf Twitch an. Chat-Etikette: höflich, aber mit ordentlich Meme-Würze.</p>
           </div>
-          <div class="timeline" role="list">
-            <article class="timeline__item" role="listitem">
-              <div class="timeline__marker" aria-hidden="true"></div>
-              <div class="timeline__content">
-                <h3>Onboarding in Minuten</h3>
-                <p>Quickstart-Assistenten helfen dir beim Einrichten von Spotify-Zugängen, Teilnehmern und Rundenregeln.</p>
+          <div class="stream__player">
+            <iframe
+              title="Twitch Stream"
+              src="https://player.twitch.tv/?channel=behamotvt&parent=www.behamot.de&parent=behamot.de&parent=behamot007.github.io&parent=localhost"
+              allowfullscreen
+            ></iframe>
+            <aside class="stream__meta">
+              <h3>Streaming Slots</h3>
+              <ul>
+                <li>Mittwoch – Strategiespiele & Chill</li>
+                <li>Freitag – Lore Stories & Collabs</li>
+                <li>Sonntag – Community Night mit Chat-Events</li>
+              </ul>
+              <a class="button button--ghost" href="https://www.twitch.tv/behamotvt/schedule" target="_blank" rel="noreferrer">Zum Schedule</a>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section id="socials" class="section section--alt" aria-labelledby="socialTitle">
+        <div class="container socials__inner">
+          <div class="section__header">
+            <span class="section__eyebrow">Social Signals</span>
+            <h2 id="socialTitle">Bleib in Verbindung</h2>
+            <p>Frische Updates auf X (Twitter), langfristige Videos auf YouTube und Live-Vibes auf Twitch.</p>
+          </div>
+          <div class="socials__grid">
+            <article class="social-card social-card--twitter">
+              <div class="social-card__header">
+                <img src="./assets/crest-divider.svg" alt="" aria-hidden="true" />
+                <div>
+                  <h3>Tweets</h3>
+                  <p>Pinned & aktuell von @BehamotVT</p>
+                </div>
               </div>
+              <a
+                class="twitter-timeline"
+                data-theme="dark"
+                data-height="420"
+                data-tweet-limit="2"
+                data-chrome="noheader nofooter noborders transparent"
+                href="https://twitter.com/BehamotVT"
+              >Tweets by BehamotVT</a>
             </article>
-            <article class="timeline__item" role="listitem">
-              <div class="timeline__marker" aria-hidden="true"></div>
-              <div class="timeline__content">
-                <h3>Live Moderation</h3>
-                <p>Geführte Moderationsansichten, Timer und Punkteverwaltung machen dich zum Game Master.</p>
+            <article class="social-card social-card--youtube">
+              <div class="social-card__header">
+                <img src="./assets/ornament-gilded.svg" alt="" aria-hidden="true" />
+                <div>
+                  <h3>YouTube</h3>
+                  <p>Recaps, Lore Logs & Musik-Uploads</p>
+                </div>
               </div>
-            </article>
-            <article class="timeline__item" role="listitem">
-              <div class="timeline__marker" aria-hidden="true"></div>
-              <div class="timeline__content">
-                <h3>Insights & Auswertung</h3>
-                <p>Analysen zu Songs, Spielverlauf und Kosten liefern Auswertungen für den nächsten Abend.</p>
-              </div>
+              <p>Abonniere den Kanal für hochwertige VODs, orchestrale Cover und Cinematics aus den Streams.</p>
+              <a class="button button--primary" href="https://www.youtube.com/@Behamot" target="_blank" rel="noreferrer">Zum YouTube-Kanal</a>
             </article>
           </div>
         </div>
       </section>
 
-      <section id="use-cases" class="section section--split" aria-labelledby="useCasesTitle">
-        <div class="container section__split">
-          <div>
-            <span class="section__eyebrow">Use Cases</span>
-            <h2 id="useCasesTitle">Bereit für Teams, Communities & Freundeskreise</h2>
+      <section id="lore" class="section" aria-labelledby="loreTitle">
+        <div class="container lore__inner">
+          <div class="section__header">
+            <span class="section__eyebrow">Lore</span>
+            <h2 id="loreTitle">Chroniken aus dem digitalen Adel</h2>
             <p>
-              Egal ob monatlicher Stammtisch, Vereins-Event oder Remote-Session – Behamot lässt sich flexibel anpassen und
-              über APIs erweitern.
+              Platzhalter für künftige Lore-Chapter. Hier erscheinen bald Geschichten über meine Herkunft, Verbündete und Rivalen im
+              virtuellen Hofstaat.
             </p>
           </div>
-          <ul class="pill-list">
-            <li>Private Musikabende</li>
-            <li>Hybrid Streams</li>
-            <li>Workshops & Meetups</li>
-            <li>Community Games</li>
-            <li>Onboarding Events</li>
-          </ul>
-        </div>
-      </section>
-
-      <section id="contact" class="section section--cta" aria-labelledby="contactTitle">
-        <div class="container section__cta">
-          <h2 id="contactTitle">Lass uns sprechen</h2>
-          <p>Du möchtest Behamot testen oder eine individuelle Session planen? Schreib uns eine kurze Nachricht.</p>
-          <a class="button button--primary" href="mailto:hello@behamot.de">hello@behamot.de</a>
+          <div class="lore__placeholder">
+            <img src="./assets/crest-divider.svg" alt="" />
+            <p>Demnächst: Kapitel 1 – "Das Erwachen des Cyber-Courtiers"</p>
+          </div>
         </div>
       </section>
     </main>
 
     <footer class="site-footer">
       <div class="container footer__inner">
-        <span>© <span id="currentYear"></span> Behamot. Crafted with Leidenschaft für digitale Abende.</span>
-        <div class="footer__links">
-          <a href="https://github.com/Behamot007" target="_blank" rel="noreferrer">GitHub</a>
-          <a href="mailto:hello@behamot.de">Kontakt</a>
+        <div class="footer__brand">
+          <img src="./assets/hero-crest.svg" alt="" />
+          <div>
+            <span class="brand__text">Behamot</span>
+            <span class="brand__role">VTuber</span>
+          </div>
         </div>
+        <nav aria-label="Footer Navigation">
+          <a href="#hero">Debut</a>
+          <a href="#about">Profil</a>
+          <a href="#stream">Livestream</a>
+          <a href="#socials">Socials</a>
+          <a href="#lore">Lore</a>
+        </nav>
+        <p class="footer__note">© <span id="year"></span> Behamot. Nobility never sleeps.</p>
       </div>
     </footer>
-
-    <script src="./script.js" defer></script>
   </body>
 </html>

--- a/projects/sites/www/sites/behemoth/script.js
+++ b/projects/sites/www/sites/behemoth/script.js
@@ -1,58 +1,23 @@
 const header = document.querySelector('.site-header');
-const navToggle = document.querySelector('.nav-toggle');
-const navLinks = document.querySelectorAll('#primaryNav a');
-const yearLabel = document.getElementById('currentYear');
+const toggle = document.querySelector('.nav-toggle');
+const nav = document.querySelector('#siteNav');
+const yearEl = document.querySelector('#year');
 
-const setYear = () => {
-  if (yearLabel) {
-    const year = new Date().getFullYear();
-    yearLabel.textContent = year;
-  }
-};
+if (toggle && header) {
+  toggle.addEventListener('click', () => {
+    const isOpen = header.dataset.navState === 'open';
+    header.dataset.navState = isOpen ? 'closed' : 'open';
+    toggle.setAttribute('aria-expanded', String(!isOpen));
+  });
 
-const closeNav = () => {
-  if (header && header.dataset.navState === 'open') {
-    header.dataset.navState = 'closed';
-    if (navToggle) {
-      navToggle.setAttribute('aria-expanded', 'false');
-    }
-  }
-};
-
-const toggleNav = () => {
-  if (!header || !navToggle) return;
-  const isOpen = header.dataset.navState === 'open';
-  header.dataset.navState = isOpen ? 'closed' : 'open';
-  navToggle.setAttribute('aria-expanded', String(!isOpen));
-};
-
-const handleKeyDown = (event) => {
-  if (event.key === 'Escape') {
-    closeNav();
-  }
-};
-
-setYear();
-
-document.addEventListener('keydown', handleKeyDown);
-
-if (navToggle) {
-  navToggle.addEventListener('click', toggleNav);
+  nav?.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      header.dataset.navState = 'closed';
+      toggle.setAttribute('aria-expanded', 'false');
+    });
+  });
 }
 
-navLinks.forEach((link) => {
-  link.addEventListener('click', () => {
-    closeNav();
-  });
-});
-
-document.addEventListener('click', (event) => {
-  if (!header || header.dataset.navState !== 'open') return;
-  const target = event.target;
-  if (!(target instanceof Element)) {
-    return;
-  }
-  if (!header.contains(target)) {
-    closeNav();
-  }
-});
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}

--- a/projects/sites/www/sites/behemoth/styles.css
+++ b/projects/sites/www/sites/behemoth/styles.css
@@ -1,36 +1,45 @@
 :root {
   color-scheme: dark;
-  --background: #080812;
-  --background-alt: #0f0f1f;
-  --surface: rgba(19, 19, 36, 0.72);
-  --surface-strong: rgba(26, 26, 48, 0.92);
-  --text-primary: #f6f6fb;
-  --text-secondary: rgba(245, 245, 247, 0.7);
-  --accent: #7a5cff;
-  --accent-strong: #9f5fff;
-  --gradient-primary: linear-gradient(135deg, rgba(104, 86, 255, 0.85), rgba(158, 89, 255, 0.95));
-  --gradient-ghost: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
-  --border: rgba(255, 255, 255, 0.08);
-  --radius-lg: 24px;
-  --radius-md: 16px;
-  --radius-sm: 12px;
-  --container-max: 1120px;
-  --shadow-soft: 0 25px 80px rgba(24, 16, 64, 0.42);
-  font-family: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #0e0b17;
+  --bg-elevated: rgba(20, 16, 35, 0.78);
+  --bg-alt: rgba(20, 18, 34, 0.9);
+  --surface: rgba(28, 24, 46, 0.85);
+  --text: #f4f0ff;
+  --text-soft: rgba(244, 240, 255, 0.7);
+  --accent: #d9b26b;
+  --accent-strong: #f0c97d;
+  --accent-soft: rgba(217, 178, 107, 0.28);
+  --ornament: rgba(143, 121, 195, 0.25);
+  --primary: #352c80;
+  --primary-dark: #1d1749;
+  --shadow: rgba(0, 0, 0, 0.4);
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 14px;
+  --max-width: 1200px;
+  --transition: 220ms ease;
+  font-size: 16px;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
 body {
   margin: 0;
-  background: radial-gradient(circle at top, rgba(122, 92, 255, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 20%, rgba(255, 104, 165, 0.08), transparent 35%),
-    var(--background);
-  color: var(--text-primary);
+  min-height: 100%;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: "Manrope", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top right, rgba(53, 44, 128, 0.4), transparent 45%),
+    radial-gradient(circle at 15% 20%, rgba(78, 54, 140, 0.55), transparent 40%), var(--bg);
+  color: var(--text);
   line-height: 1.6;
-  letter-spacing: -0.01em;
+  position: relative;
+  overflow-x: hidden;
 }
 
 img {
@@ -43,80 +52,188 @@ a {
 }
 
 .container {
-  width: min(100% - 2.5rem, var(--container-max));
-  margin-inline: auto;
+  width: min(calc(100% - 2.5rem), var(--max-width));
+  margin: 0 auto;
+}
+
+.section {
+  padding: clamp(4rem, 6vw, 6rem) 0;
+}
+
+.section--alt {
+  background: linear-gradient(145deg, rgba(22, 18, 39, 0.92), rgba(16, 12, 30, 0.88));
+  position: relative;
+  overflow: hidden;
+}
+
+.section--alt::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(120, 99, 189, 0.28), transparent 60%);
+  opacity: 0.6;
+}
+
+.section--alt > * {
+  position: relative;
+  z-index: 1;
+}
+
+.section__header {
+  max-width: 720px;
+  margin-bottom: clamp(2rem, 5vw, 3rem);
+}
+
+.section__eyebrow,
+.eyebrow {
+  font-family: "Playfair Display", serif;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+  font-size: 0.8rem;
+  display: inline-block;
+  margin-bottom: 1rem;
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Playfair Display", serif;
+  margin: 0 0 1rem;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 3vw + 1.4rem, 3.6rem);
+}
+
+h2 {
+  font-size: clamp(1.8rem, 2vw + 1.2rem, 2.6rem);
+}
+
+h3 {
+  font-size: clamp(1.2rem, 1vw + 0.9rem, 1.6rem);
+}
+
+p {
+  margin: 0 0 1.6rem;
+  color: var(--text-soft);
 }
 
 .site-header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: rgba(8, 8, 20, 0.85);
-  backdrop-filter: blur(24px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  background: linear-gradient(180deg, rgba(14, 11, 23, 0.95), rgba(14, 11, 23, 0.65));
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(217, 178, 107, 0.18);
 }
 
 .header__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-block: 1rem;
+  padding: 1.2rem 0;
+  gap: 1.25rem;
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.6rem;
-  font-weight: 700;
-  font-size: 1.1rem;
+  gap: 0.75rem;
   text-decoration: none;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  color: var(--text);
 }
 
-.brand__accent {
+.brand__mark {
+  width: 38px;
+  filter: drop-shadow(0 10px 18px rgba(240, 201, 125, 0.25));
+}
+
+.brand__text {
+  font-family: "Playfair Display", serif;
   font-size: 1.2rem;
-  color: var(--accent);
+  letter-spacing: 0.08em;
+}
+
+.brand__role {
+  font-size: 0.8rem;
+  letter-spacing: 0.34em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.primary-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.primary-nav a {
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+  position: relative;
+  padding-bottom: 0.3rem;
+  transition: color var(--transition);
+}
+
+.primary-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  opacity: 0;
+  transform: scaleX(0.4);
+  transition: opacity var(--transition), transform var(--transition);
+}
+
+.primary-nav a:focus-visible,
+.primary-nav a:hover {
+  color: var(--text);
+}
+
+.primary-nav a:hover::after,
+.primary-nav a:focus-visible::after {
+  opacity: 1;
+  transform: scaleX(1);
 }
 
 .nav-toggle {
   display: none;
   background: none;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(217, 178, 107, 0.25);
+  color: var(--text);
+  padding: 0.5rem 0.85rem;
   border-radius: 999px;
-  padding: 0.35rem 0.85rem;
-  color: var(--text-primary);
+  font-size: 0.85rem;
   font-weight: 600;
-  gap: 0.6rem;
-  align-items: center;
-}
-
-.nav-toggle__label {
-  margin-right: 0.5rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .nav-toggle__icon {
+  display: inline-block;
+  width: 22px;
+  height: 2px;
+  background: var(--accent-strong);
   position: relative;
-  width: 1.25rem;
-  height: 0.875rem;
+  transition: transform var(--transition), background var(--transition);
 }
 
 .nav-toggle__icon::before,
-.nav-toggle__icon::after,
-.nav-toggle__icon {
-  display: block;
-  background: currentColor;
-  content: '';
-  height: 2px;
-  border-radius: 999px;
+.nav-toggle__icon::after {
+  content: "";
   position: absolute;
-  inset-inline: 0;
-  transition: transform 0.4s ease, opacity 0.3s ease;
-}
-
-.nav-toggle__icon {
-  top: 50%;
-  transform: translateY(-50%);
+  left: 0;
+  width: 22px;
+  height: 2px;
+  background: inherit;
+  transition: transform var(--transition), opacity var(--transition);
 }
 
 .nav-toggle__icon::before {
@@ -127,59 +244,34 @@ a {
   top: 6px;
 }
 
-.primary-nav {
-  display: flex;
-  gap: 1.75rem;
-  align-items: center;
-  font-weight: 500;
+.site-header[data-nav-state="open"] .nav-toggle__icon {
+  background: transparent;
 }
 
-.primary-nav a {
-  text-decoration: none;
-  color: var(--text-secondary);
-  transition: color 0.2s ease;
+.site-header[data-nav-state="open"] .nav-toggle__icon::before {
+  transform: translateY(6px) rotate(45deg);
 }
 
-.primary-nav a:hover,
-.primary-nav a:focus-visible {
-  color: var(--text-primary);
-}
-
-.hero {
-  padding: clamp(6rem, 10vw, 8rem) 0 5rem;
+.site-header[data-nav-state="open"] .nav-toggle__icon::after {
+  transform: translateY(-6px) rotate(-45deg);
 }
 
 .hero__inner {
   display: grid;
-  gap: 3rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: center;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.hero__content h1 {
-  font-size: clamp(2.45rem, 5vw, 3.5rem);
-  margin-bottom: 1rem;
+  gap: clamp(2rem, 5vw, 4.5rem);
 }
 
 .hero__content p {
-  color: var(--text-secondary);
   font-size: 1.05rem;
-}
-
-.eyebrow {
-  display: inline-block;
-  font-size: 0.85rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
-  margin-bottom: 1.25rem;
 }
 
 .hero__actions {
   display: flex;
-  gap: 1rem;
   flex-wrap: wrap;
-  margin-block: 2.2rem 2.5rem;
+  gap: 1rem;
+  margin: 2rem 0 2.5rem;
 }
 
 .button {
@@ -188,395 +280,360 @@ a {
   justify-content: center;
   padding: 0.85rem 1.8rem;
   border-radius: 999px;
-  border: none;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
   text-decoration: none;
-  transition: transform 0.18s ease, box-shadow 0.2s ease;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
 }
 
 .button--primary {
-  background: var(--gradient-primary);
+  background: linear-gradient(135deg, #5036a8, #7b5de3);
   color: #fff;
-  box-shadow: 0 18px 45px rgba(122, 92, 255, 0.35);
+  box-shadow: 0 18px 38px rgba(85, 65, 184, 0.5);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 22px 42px rgba(85, 65, 184, 0.6);
 }
 
 .button--ghost {
-  background: var(--gradient-ghost);
-  color: var(--text-primary);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(217, 178, 107, 0.12);
+  color: var(--accent-strong);
+  border: 1px solid rgba(217, 178, 107, 0.3);
 }
 
-.button:hover,
-.button:focus-visible {
-  transform: translateY(-2px);
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  background: rgba(217, 178, 107, 0.22);
 }
 
-.hero__meta {
-  display: flex;
-  gap: 2.5rem;
-  flex-wrap: wrap;
-  color: var(--text-secondary);
-}
-
-.hero__meta dt {
-  font-size: 2rem;
-  color: var(--text-primary);
-  font-weight: 700;
-}
-
-.hero__meta dd {
+.hero__stats {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   margin: 0;
+}
+
+.hero__stats dt {
+  font-family: "Playfair Display", serif;
+  font-size: 1.1rem;
+  color: var(--accent-strong);
+  margin-bottom: 0.4rem;
+}
+
+.hero__stats dd {
+  margin: 0;
+  color: var(--text-soft);
   font-size: 0.95rem;
 }
 
 .hero__visual {
-  position: relative;
-  padding: 3rem;
-}
-
-.orb {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(0);
-  opacity: 0.65;
-}
-
-.orb--primary {
-  width: 220px;
-  height: 220px;
-  top: 20%;
-  right: 10%;
-  background: radial-gradient(circle, rgba(134, 112, 255, 0.8), rgba(134, 112, 255, 0));
-}
-
-.orb--secondary {
-  width: 320px;
-  height: 320px;
-  bottom: 10%;
-  left: 8%;
-  background: radial-gradient(circle, rgba(255, 112, 181, 0.7), rgba(255, 112, 181, 0));
-}
-
-.screen-mockup {
-  position: relative;
-  background: rgba(10, 10, 20, 0.9);
-  border-radius: var(--radius-lg);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  padding: 1.5rem;
-  max-width: 360px;
-  margin: 0 auto;
-  box-shadow: var(--shadow-soft);
-}
-
-.screen-mockup__header {
   display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  justify-content: center;
 }
 
-.screen-mockup__header span {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.2);
+.portrait-frame {
+  position: relative;
+  width: min(520px, 90%);
 }
 
-.screen-mockup__badge {
-  display: inline-flex;
+.portrait-frame__base {
+  width: 100%;
+  filter: drop-shadow(0 28px 50px rgba(12, 9, 20, 0.75));
+}
+
+.portrait-frame__inner {
+  position: absolute;
+  inset: 11% 10%;
+  border-radius: 32px;
+  padding: 1.6rem;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.portrait-frame__character {
+  width: 78%;
+  mix-blend-mode: screen;
+  filter: drop-shadow(0 24px 38px rgba(17, 11, 32, 0.7));
+}
+
+.portrait-frame__expressions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  width: 100%;
+}
+
+.portrait-frame__expressions figure {
+  margin: 0;
+  text-align: center;
   font-size: 0.75rem;
-  padding: 0.35rem 0.8rem;
-  border-radius: 999px;
-  background: rgba(122, 92, 255, 0.12);
-  color: rgba(122, 92, 255, 0.9);
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--accent-strong);
 }
 
-.screen-mockup__body h2 {
-  margin: 1rem 0 0.5rem;
+.portrait-frame__expressions img {
+  width: 70px;
+  height: 70px;
+  object-fit: contain;
+  margin-bottom: 0.4rem;
 }
 
-.screen-mockup__body p {
-  color: var(--text-secondary);
-  margin-bottom: 1rem;
-  font-size: 0.95rem;
+.about__inner .highlight-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.screen-mockup__body ul {
+.highlight-card {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  border: 1px solid rgba(217, 178, 107, 0.18);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 30px 60px rgba(6, 4, 12, 0.45);
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.highlight-card:hover,
+.highlight-card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(217, 178, 107, 0.45);
+}
+
+.highlight-card img {
+  width: 60px;
+  margin-bottom: 1.2rem;
+}
+
+.stream__player {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  align-items: start;
+  background: rgba(18, 14, 28, 0.88);
+  padding: 2rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(217, 178, 107, 0.18);
+  box-shadow: 0 28px 60px rgba(7, 5, 14, 0.5);
+}
+
+.stream__player iframe {
+  width: 100%;
+  min-height: 340px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: #000;
+}
+
+.stream__meta ul {
   list-style: none;
-  margin: 0;
+  margin: 0 0 1.5rem;
   padding: 0;
   display: grid;
-  gap: 0.5rem;
-  font-size: 0.92rem;
+  gap: 0.85rem;
 }
 
-.screen-mockup__body li::before {
-  content: '•';
+.stream__meta li::before {
+  content: "◆";
   color: var(--accent);
   margin-right: 0.5rem;
 }
 
-.section {
-  padding: clamp(4.5rem, 8vw, 6rem) 0;
-}
-
-.section--alt {
-  background: var(--background-alt);
-}
-
-.section__inner {
+.socials__grid {
   display: grid;
-  gap: 3rem;
-}
-
-.section__header {
-  max-width: 680px;
-}
-
-.section__header p {
-  color: var(--text-secondary);
-}
-
-.section__eyebrow {
-  display: inline-block;
-  font-size: 0.85rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.5);
-  margin-bottom: 1.2rem;
-}
-
-.feature-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.8rem;
-}
-
-.feature-card {
-  background: var(--surface);
-  border-radius: var(--radius-md);
-  padding: 1.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 20px 45px rgba(12, 12, 32, 0.4);
-}
-
-.feature-card h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-}
-
-.feature-card p {
-  color: var(--text-secondary);
-}
-
-.timeline {
-  position: relative;
-  padding-left: 1.5rem;
-  margin: 0;
-  display: grid;
-  gap: 1.75rem;
-}
-
-.timeline::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0.4rem;
-  bottom: 0;
-  width: 1px;
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.timeline__item {
-  display: grid;
-  grid-template-columns: auto 1fr;
   gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.timeline__marker {
-  width: 0.9rem;
-  height: 0.9rem;
-  border-radius: 50%;
-  background: var(--accent);
-  margin-top: 0.4rem;
-  box-shadow: 0 0 0 6px rgba(122, 92, 255, 0.15);
+.social-card {
+  background: rgba(12, 10, 22, 0.88);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  border: 1px solid rgba(217, 178, 107, 0.2);
+  box-shadow: 0 30px 60px rgba(4, 3, 10, 0.45);
+  min-height: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
 }
 
-.timeline__content h3 {
-  margin: 0 0 0.6rem;
-}
-
-.timeline__content p {
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-.section--split .section__split {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+.social-card__header {
+  display: flex;
+  gap: 1.2rem;
   align-items: center;
 }
 
-.pill-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+.social-card__header img {
+  width: 48px;
+  filter: drop-shadow(0 12px 24px rgba(217, 178, 107, 0.3));
 }
 
-.pill-list li {
-  padding: 0.6rem 1.2rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  font-weight: 500;
-  letter-spacing: 0.02em;
+.social-card--twitter {
+  background: linear-gradient(160deg, rgba(18, 15, 32, 0.92), rgba(16, 18, 42, 0.92));
 }
 
-.section--cta {
-  background: radial-gradient(circle at 20% 20%, rgba(122, 92, 255, 0.25), transparent 60%),
-    radial-gradient(circle at 80% 10%, rgba(255, 104, 165, 0.18), transparent 55%),
-    rgba(12, 12, 24, 0.95);
+.social-card--youtube {
+  justify-content: space-between;
+}
+
+.twitter-timeline {
+  border-radius: var(--radius-md);
+}
+
+.lore__placeholder {
+  margin-top: 2rem;
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(217, 178, 107, 0.4);
+  padding: 2.5rem;
   text-align: center;
-}
-
-.section__cta {
+  background: rgba(14, 12, 24, 0.8);
   display: grid;
   gap: 1.5rem;
   justify-items: center;
 }
 
-.section__cta p {
-  max-width: 520px;
-  color: var(--text-secondary);
+.lore__placeholder img {
+  width: 64px;
 }
 
 .site-footer {
-  padding: 2rem 0 3rem;
-  background: rgba(6, 6, 14, 0.92);
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 3rem 0;
+  border-top: 1px solid rgba(217, 178, 107, 0.18);
+  background: rgba(10, 8, 18, 0.96);
 }
 
 .footer__inner {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: space-between;
+  gap: 2rem;
   align-items: center;
-  color: rgba(245, 245, 247, 0.6);
-  font-size: 0.9rem;
+  justify-content: space-between;
 }
 
-.footer__links {
+.footer__brand {
   display: inline-flex;
-  gap: 1.5rem;
+  align-items: center;
+  gap: 1rem;
 }
 
-.footer__links a {
-  color: inherit;
+.footer__brand img {
+  width: 48px;
+  filter: drop-shadow(0 12px 22px rgba(217, 178, 107, 0.25));
+}
+
+.site-footer nav {
+  display: inline-flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.site-footer nav a {
   text-decoration: none;
-  position: relative;
+  font-size: 0.9rem;
+  color: var(--text-soft);
 }
 
-.footer__links a::after {
-  content: '';
+.footer__note {
+  margin: 0;
+  color: rgba(244, 240, 255, 0.55);
+  font-size: 0.85rem;
+}
+
+.background-lights {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: -1;
+  opacity: 0.8;
+}
+
+.bg-crest {
   position: absolute;
-  left: 0;
-  bottom: -0.2rem;
-  width: 100%;
-  height: 1px;
-  background: rgba(255, 255, 255, 0.3);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.2s ease;
+  width: 420px;
+  filter: blur(2px) drop-shadow(0 40px 60px rgba(10, 7, 18, 0.8));
+  opacity: 0.28;
 }
 
-.footer__links a:hover::after,
-.footer__links a:focus-visible::after {
-  transform: scaleX(1);
+.bg-crest--left {
+  top: -80px;
+  left: -120px;
 }
 
-@media (max-width: 900px) {
-  .primary-nav {
-    position: fixed;
-    inset-inline: 1.5rem;
-    top: 4.5rem;
-    background: rgba(8, 8, 20, 0.98);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: var(--radius-md);
-    padding: 1.5rem;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1.25rem;
-    transform: translateY(-1.5rem);
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.25s ease, transform 0.25s ease;
+.bg-crest--right {
+  bottom: -120px;
+  right: -100px;
+  transform: scaleX(-1);
+}
+
+@media (max-width: 960px) {
+  .hero__inner {
+    grid-template-columns: 1fr;
+    text-align: center;
   }
 
-  .site-header[data-nav-state='open'] .primary-nav {
-    opacity: 1;
-    pointer-events: auto;
+  .hero__actions {
+    justify-content: center;
+  }
+
+  .portrait-frame__inner {
+    inset: 12% 14%;
+  }
+
+  .stream__player {
+    grid-template-columns: 1fr;
+  }
+
+  .primary-nav {
+    position: fixed;
+    inset: 0 0 auto;
+    transform: translateY(-100%);
+    opacity: 0;
+    background: rgba(10, 8, 18, 0.96);
+    padding: 4.5rem 1.5rem 2rem;
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: flex-start;
+    border-bottom: 1px solid rgba(217, 178, 107, 0.2);
+    transition: transform var(--transition), opacity var(--transition);
+  }
+
+  .site-header[data-nav-state="open"] .primary-nav {
     transform: translateY(0);
+    opacity: 1;
   }
 
   .nav-toggle {
     display: inline-flex;
   }
-
-  .site-header[data-nav-state='open'] .nav-toggle {
-    color: var(--accent);
-  }
-
-  .site-header[data-nav-state='open'] .nav-toggle__icon::before {
-    transform: translateY(6px) rotate(45deg);
-  }
-
-  .site-header[data-nav-state='open'] .nav-toggle__icon::after {
-    transform: translateY(-6px) rotate(-45deg);
-  }
-
-  .site-header[data-nav-state='open'] .nav-toggle__icon {
-    background: transparent;
-  }
 }
 
-@media (max-width: 600px) {
-  .hero {
-    padding-top: 5rem;
+@media (max-width: 680px) {
+  :root {
+    font-size: 15px;
   }
 
-  .hero__visual {
-    padding: 2rem 1rem 1rem;
+  .section {
+    padding: 3.5rem 0;
   }
 
-  .hero__actions {
-    justify-content: stretch;
+  .hero__stats {
+    grid-template-columns: 1fr;
   }
 
-  .button {
-    width: 100%;
+  .portrait-frame__expressions {
+    flex-wrap: wrap;
   }
 
-  .timeline {
-    padding-left: 1rem;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
+  .stream__player iframe {
+    min-height: 260px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the previous behemoth landing page with a VTuber-themed one-page debut site for Behamot
- embed Twitch livestream, Twitter timeline, and YouTube CTA alongside highlight, profile, and lore placeholder sections
- add bespoke SVG assets that mirror the character sheet aesthetic and support the new layout styling

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dd90996a54832f979c360a1ee59b06