### PR TITLE
Add asset showcase section for Behamot site

### DIFF
--- a/projects/sites/www/sites/behemoth/index.html
+++ b/projects/sites/www/sites/behemoth/index.html
@@ -40,6 +40,7 @@
           <a href="#about">Profil</a>
           <a href="#stream">Livestream</a>
           <a href="#socials">Socials</a>
+          <a href="#assets">Assets</a>
           <a href="#lore">Lore</a>
         </nav>
       </div>
@@ -195,6 +196,132 @@
         </div>
       </section>
 
+      <section id="assets" class="section assets section--alt" aria-labelledby="assetsTitle">
+        <div class="container assets__inner">
+          <div class="section__header">
+            <span class="section__eyebrow">Visual Identity</span>
+            <h2 id="assetsTitle">Brand Assets für Stream & Community</h2>
+            <p>
+              Eine Auswahl an Charakter-Artworks, Emotes, Badges und Bannern, die den höfischen Stil von Behamot prägen. Ideal
+              für Szenen, Panels und Community-Beiträge.
+            </p>
+          </div>
+          <div class="character-showcase">
+            <figure class="character-showcase__figure">
+              <img src="../../assets/CharakterSheet.jpg" alt="Charakter Sheet von Behamot mit kompletter Outfit-Ansicht" loading="lazy" />
+              <figcaption>Artwork von RahmatN · Design-Guide für Adels-Looks</figcaption>
+            </figure>
+            <div class="character-showcase__content">
+              <h3>Charakter Sheet Highlights</h3>
+              <p>
+                Farbpalette in Gold & Violett, ornamentale Stickereien und technoide Accessoires schaffen den Spagat zwischen
+                höfischer Tradition und futuristischer Bühne.
+              </p>
+              <ul class="character-showcase__details">
+                <li>Mehrere Layer für Outfit-Varianten – perfekt für Assets in Overlays und Thumbnails.</li>
+                <li>Klare Silhouette für 2D/3D Rigs und einheitliche Beleuchtung für Compositing.</li>
+                <li>Beinhaltet Accessoires wie Fächer, Orden und Lichtornamente zur freien Kombination.</li>
+              </ul>
+            </div>
+          </div>
+          <div class="asset-panels">
+            <article class="asset-panel">
+              <div class="asset-panel__header">
+                <img src="./assets/ornament-gilded.svg" alt="" aria-hidden="true" />
+                <div>
+                  <h3>Emote Kollektion</h3>
+                  <p>Emotionale Reaktionen mit höfischem Charme für Chat & Discord.</p>
+                </div>
+              </div>
+              <div class="emote-grid" role="list">
+                <figure class="emote-grid__item" role="listitem">
+                  <img src="../../assets/Emotes/Hi.png" alt="Emote: höfischer Gruß" loading="lazy" />
+                  <figcaption>Hi</figcaption>
+                </figure>
+                <figure class="emote-grid__item" role="listitem">
+                  <img src="../../assets/Emotes/Moth_Heart.png" alt="Emote: Herz mit Flügeln" loading="lazy" />
+                  <figcaption>Heart</figcaption>
+                </figure>
+                <figure class="emote-grid__item" role="listitem">
+                  <img src="../../assets/Emotes/Hmmm.png" alt="Emote: nachdenklicher Blick" loading="lazy" />
+                  <figcaption>Hmmm</figcaption>
+                </figure>
+                <figure class="emote-grid__item" role="listitem">
+                  <img src="../../assets/Emotes/WOOOW.png" alt="Emote: begeistertes Staunen" loading="lazy" />
+                  <figcaption>Wow</figcaption>
+                </figure>
+                <figure class="emote-grid__item" role="listitem">
+                  <img src="../../assets/Emotes/Crying.png" alt="Emote: Tränen der Rührung" loading="lazy" />
+                  <figcaption>Feels</figcaption>
+                </figure>
+                <figure class="emote-grid__item" role="listitem">
+                  <img src="../../assets/Emotes/Glowstick.png" alt="Emote: Glowstick für Hype-Momente" loading="lazy" />
+                  <figcaption>Glow</figcaption>
+                </figure>
+              </div>
+            </article>
+            <article class="asset-panel">
+              <div class="asset-panel__header">
+                <img src="./assets/crest-divider.svg" alt="" aria-hidden="true" />
+                <div>
+                  <h3>Mitglieds-Badges</h3>
+                  <p>Progressive Insignien für Mitglieder – je länger dabei, desto mehr Glanz.</p>
+                </div>
+              </div>
+              <div class="badge-row" role="list">
+                <figure class="badge-row__item" role="listitem">
+                  <img src="../../assets/badges/Month1_900.png" alt="Mitglieds-Badge für Monat 1" loading="lazy" />
+                  <figcaption>Monat 1</figcaption>
+                </figure>
+                <figure class="badge-row__item" role="listitem">
+                  <img src="../../assets/badges/Month3_1000px.png" alt="Mitglieds-Badge für Monat 3" loading="lazy" />
+                  <figcaption>Monat 3</figcaption>
+                </figure>
+                <figure class="badge-row__item" role="listitem">
+                  <img src="../../assets/badges/Month6_1000px.png" alt="Mitglieds-Badge für Monat 6" loading="lazy" />
+                  <figcaption>Monat 6</figcaption>
+                </figure>
+                <figure class="badge-row__item" role="listitem">
+                  <img src="../../assets/badges/Month9_1000px.png" alt="Mitglieds-Badge für Monat 9" loading="lazy" />
+                  <figcaption>Monat 9</figcaption>
+                </figure>
+                <figure class="badge-row__item" role="listitem">
+                  <img src="../../assets/badges/Month12_1000px.png" alt="Mitglieds-Badge für Monat 12" loading="lazy" />
+                  <figcaption>Monat 12</figcaption>
+                </figure>
+                <figure class="badge-row__item" role="listitem">
+                  <img src="../../assets/badges/Month18_1000px.png" alt="Mitglieds-Badge für Monat 18" loading="lazy" />
+                  <figcaption>Monat 18</figcaption>
+                </figure>
+              </div>
+            </article>
+            <article class="asset-panel">
+              <div class="asset-panel__header">
+                <img src="./assets/ornament-gilded.svg" alt="" aria-hidden="true" />
+                <div>
+                  <h3>Brand Banner & Logo</h3>
+                  <p>Saisonale Panels und das Logo für Webseiten, Panels und Offline-Werbung.</p>
+                </div>
+              </div>
+              <div class="banner-gallery">
+                <figure>
+                  <img src="../../assets/banner/BannerSommer.jpeg" alt="Sommerbanner mit Goldakzenten" loading="lazy" />
+                  <figcaption>Sommer Edition</figcaption>
+                </figure>
+                <figure>
+                  <img src="../../assets/banner/Bannerfruehling.jpeg" alt="Frühlingsbanner mit floralen Elementen" loading="lazy" />
+                  <figcaption>Frühlings Edition</figcaption>
+                </figure>
+                <figure>
+                  <img src="../../assets/BehamotVtLogo.png" alt="Logo von Behamot" loading="lazy" />
+                  <figcaption>Markenzeichen</figcaption>
+                </figure>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
       <section id="lore" class="section" aria-labelledby="loreTitle">
         <div class="container lore__inner">
           <div class="section__header">
@@ -227,6 +354,7 @@
           <a href="#about">Profil</a>
           <a href="#stream">Livestream</a>
           <a href="#socials">Socials</a>
+          <a href="#assets">Assets</a>
           <a href="#lore">Lore</a>
         </nav>
         <p class="footer__note">© <span id="year"></span> Behamot. Nobility never sleeps.</p>

--- a/projects/sites/www/sites/behemoth/styles.css
+++ b/projects/sites/www/sites/behemoth/styles.css
@@ -465,6 +465,206 @@ p {
   gap: 1.2rem;
 }
 
+.assets__inner {
+  display: grid;
+  gap: clamp(3rem, 6vw, 4.5rem);
+}
+
+.character-showcase {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  gap: clamp(2rem, 5vw, 3.5rem);
+  align-items: center;
+}
+
+.character-showcase__figure {
+  margin: 0;
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid rgba(217, 178, 107, 0.2);
+  box-shadow: 0 30px 60px rgba(6, 4, 12, 0.5);
+}
+
+.character-showcase__figure img {
+  width: 100%;
+  display: block;
+}
+
+.character-showcase__figure figcaption {
+  position: absolute;
+  inset: auto 0 0;
+  padding: 1rem 1.5rem;
+  background: linear-gradient(180deg, transparent, rgba(10, 8, 18, 0.92));
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(244, 240, 255, 0.72);
+}
+
+.character-showcase__content {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(217, 178, 107, 0.2);
+  padding: clamp(1.8rem, 3vw, 2.4rem);
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: 0 26px 52px rgba(7, 5, 15, 0.48);
+}
+
+.character-showcase__details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.character-showcase__details li {
+  display: flex;
+  gap: 0.75rem;
+  color: var(--text-soft);
+  align-items: flex-start;
+}
+
+.character-showcase__details li::before {
+  content: "✶";
+  color: var(--accent-strong);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  margin-top: 0.2rem;
+}
+
+.asset-panels {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.asset-panel {
+  background: rgba(12, 10, 22, 0.9);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(217, 178, 107, 0.22);
+  padding: clamp(1.6rem, 2.5vw, 2.1rem);
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: 0 26px 50px rgba(5, 4, 12, 0.48);
+}
+
+.asset-panel__header {
+  display: flex;
+  gap: 1.1rem;
+  align-items: center;
+}
+
+.asset-panel__header img {
+  width: 42px;
+  filter: drop-shadow(0 16px 26px rgba(217, 178, 107, 0.28));
+}
+
+.asset-panel__header h3 {
+  margin-bottom: 0.25rem;
+}
+
+.asset-panel__header p {
+  margin: 0;
+  color: var(--text-soft);
+}
+
+.emote-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
+  justify-items: center;
+}
+
+.emote-grid__item {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
+  text-align: center;
+}
+
+.emote-grid__item img {
+  width: 70px;
+  height: 70px;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
+  padding: 0.6rem;
+  background: rgba(217, 178, 107, 0.08);
+  border: 1px solid rgba(217, 178, 107, 0.24);
+  box-shadow: 0 18px 36px rgba(6, 5, 14, 0.45);
+}
+
+.emote-grid__item figcaption {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(244, 240, 255, 0.65);
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.badge-row__item {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
+  text-align: center;
+}
+
+.badge-row__item img {
+  width: 72px;
+  height: 72px;
+  object-fit: contain;
+  background: rgba(217, 178, 107, 0.1);
+  border-radius: 50%;
+  padding: 0.45rem;
+  border: 1px solid rgba(217, 178, 107, 0.28);
+  box-shadow: 0 18px 36px rgba(6, 4, 12, 0.4);
+}
+
+.badge-row__item figcaption {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(244, 240, 255, 0.65);
+}
+
+.banner-gallery {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.banner-gallery figure {
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.banner-gallery img {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(217, 178, 107, 0.2);
+  box-shadow: 0 20px 40px rgba(5, 4, 12, 0.45);
+  object-fit: cover;
+  max-height: 220px;
+}
+
+.banner-gallery figcaption {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(244, 240, 255, 0.65);
+}
+
 .social-card__header {
   display: flex;
   gap: 1.2rem;
@@ -613,6 +813,10 @@ p {
 
   .nav-toggle {
     display: inline-flex;
+  }
+
+  .character-showcase {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a new navigation target and assets section that highlights character sheet, emotes, badges and banners
- style the new section with ornamented cards and responsive grids that match the existing noble theme

## Testing
- Manually previewed in browser

------
https://chatgpt.com/codex/tasks/task_e_68dd9aed99b8832f8f71d5c0e3a4fb99