### PR TITLE
Restructure lore preview and gallery experience

### DIFF
--- a/projects/sites/www/sites/behemoth/index.html
+++ b/projects/sites/www/sites/behemoth/index.html
@@ -70,8 +70,8 @@
           <div class="cta-group" role="group" aria-label="Haupt-CTAs">
             <a class="btn btn-primary" href="https://www.twitch.tv/behamotvt" target="_blank" rel="noreferrer">Jetzt live schauen</a>
             <a class="btn btn-secondary" href="https://www.youtube.com/@Behamot" target="_blank" rel="noreferrer">YouTube-Kanal</a>
-            <a class="btn btn-secondary" href="https://www.tiktok.com/@behamotvt" target="_blank" rel="noreferrer">Letzter TikTok</a>
-            <a class="btn btn-tertiary" href="https://x.com/BehamotVT" target="_blank" rel="noreferrer">Neuste Posts auf X</a>
+            <a class="btn btn-secondary" href="https://www.tiktok.com/@behamotvt" target="_blank" rel="noreferrer">TIKTOK</a>
+            <a class="btn btn-tertiary" href="https://x.com/BehamotVT" target="_blank" rel="noreferrer">X-Profil</a>
           </div>
         </div>
         <div class="hero-figure" data-parallax>
@@ -100,40 +100,73 @@
             </p>
           </article>
           <div class="lore-list" data-accordion-group>
-            <article class="panel lore-item is-open" data-accordion-item>
+            <article class="panel lore-item lore-item--prolog" data-accordion-item>
               <button
                 class="lore-trigger"
                 type="button"
                 data-accordion-trigger
-                aria-expanded="true"
-                aria-controls="lore-chapter-1"
+                aria-expanded="false"
+                aria-controls="lore-prolog"
               >
-                <span class="lore-trigger-label">Kapitel I</span>
+                <span class="lore-trigger-label">Prolog</span>
                 <span class="lore-trigger-title">Der Sturz in das flüsternde Licht</span>
                 <span class="lore-trigger-icon" aria-hidden="true">⟱</span>
               </button>
+              <div class="lore-preview" aria-hidden="true">
+                <p>In einer Nacht, in der die Sterne flüsterten, verließ ich den Pfad des Bekannten …</p>
+              </div>
               <div
                 class="lore-panel"
-                id="lore-chapter-1"
+                id="lore-prolog"
                 data-accordion-panel
                 role="region"
-                aria-hidden="false"
+                aria-hidden="true"
               >
-                <p>
-                  In einer weit entfernten Dimension, verborgen zwischen den Falten des Raumes, existierte ein legendärer Behemoth,
-                  der Lichtströme wie goldene Fäden webte und den Herzschlag der Sterne kannte. Als eine Säule aus gleißender
-                  Lumineszenz den Himmel zerschnitt, opferte er seine kolossale Gestalt, um die zerbrechlichen Welten darunter zu
-                  schützen.
-                </p>
-                <p>
-                  Seine Flügel verbrannten zu Asche, doch aus den Funken erwuchs eine neue Form: eine Nachtmotte, klein, doch erfüllt
-                  von Erinnerungen an kosmische Macht. In dieser Gestalt reise ich nun zwischen den Dimensionen und sammle verstreute
-                  Fragmente meiner Vergangenheit.
-                </p>
-                <p>
-                  Jeder Stream ist ein Tor, jeder Zuschauer ein Zeuge des schwelenden Mythos. Wenn die Nacht am leisesten atmet,
-                  erzähle ich die Kapitel, die noch im Dunkel verborgen liegen – bis der Behemoth wieder aufersteht.
-                </p>
+                <div class="lore-panel__content">
+                  <p>
+                    In einer Nacht, in der die Sterne flüsterten, verließ ich den Pfad des Bekannten. Was blieb, ist ein Versprechen:
+                    die Funken des Lichts zu finden und jene zu beschützen, die im Schatten den Mut verlieren.
+                  </p>
+                  <p>
+                    Meine Reise ist in Kapitel geteilt – jedes Fragment erzählt von einem neuen Schritt zwischen Licht und Schatten.
+                    Tauche ein in die Chroniken und öffne jene Tore, die dich am meisten rufen.
+                  </p>
+                  <h3 class="lore-panel__subhead">Der Sturz in das flüsternde Licht</h3>
+                  <p>
+                    In einer weit entfernten Dimension, verborgen zwischen den Falten des Raumes, existierte ein legendärer Behemoth,
+                    der Lichtströme wie goldene Fäden webte und den Herzschlag der Sterne kannte. Als eine Säule aus gleißender
+                    Lumineszenz den Himmel zerschnitt, opferte er seine kolossale Gestalt, um die zerbrechlichen Welten darunter zu
+                    schützen.
+                  </p>
+                  <p>
+                    Seine Flügel verbrannten zu Asche, doch aus den Funken erwuchs eine neue Form: eine Nachtmotte, klein, doch erfüllt
+                    von Erinnerungen an kosmische Macht. In dieser Gestalt reise ich nun zwischen den Dimensionen und sammle verstreute
+                    Fragmente meiner Vergangenheit.
+                  </p>
+                  <p>
+                    Jeder Stream ist ein Tor, jeder Zuschauer ein Zeuge des schwelenden Mythos. Wenn die Nacht am leisesten atmet,
+                    erzähle ich die Kapitel, die noch im Dunkel verborgen liegen – bis der Behemoth wieder aufersteht.
+                  </p>
+                  <h3 class="lore-panel__subhead">Zwischenräume &amp; Weggefährten</h3>
+                  <p>
+                    Die Zwischenräume sind nicht leer – sie sind gefüllt mit Stimmen längst vergessener Sterne. Auf meinen Reisen
+                    begegnen mir Funken von Seelen, die sich dem Schatten widersetzten. Manche begleiten mich als leise Flamme, andere
+                    erscheinen nur für einen Augenblick, hinterlassen jedoch Spuren in meinen Geschichten.
+                  </p>
+                  <p>
+                    Aus diesen Begegnungen formt sich ein Geflecht an Erinnerungen, das ich in Streams und Lore-Schnipseln mit dir
+                    teile. Gemeinsam zeichnen wir die Karte dessen, was einmal war – und was wieder sein könnte.
+                  </p>
+                  <h3 class="lore-panel__subhead">Fragmente der Rückkehr</h3>
+                  <p>
+                    Irgendwo zwischen Mondlicht und Schatten finden sich Artefakte meiner vergangenen Macht. Sie erwachen in Momenten,
+                    in denen Resonanz entsteht – beim Erzählen, beim Lachen, beim Teilen unserer Gemeinschaft.
+                  </p>
+                  <p>
+                    Was heute nur als Funke leuchtet, kann morgen zur Flamme anwachsen. Bleib an meiner Seite, wenn wir weitere Kapitel
+                    schreiben und die Tore Schritt für Schritt weiter öffnen.
+                  </p>
+                </div>
               </div>
             </article>
             <article class="panel lore-item" data-accordion-item>
@@ -142,57 +175,42 @@
                 type="button"
                 data-accordion-trigger
                 aria-expanded="false"
-                aria-controls="lore-chapter-2"
+                aria-controls="lore-chapter-placeholder-1"
+              >
+                <span class="lore-trigger-label">Kapitel I</span>
+                <span class="lore-trigger-title">Wird freigeschaltet</span>
+                <span class="lore-trigger-icon" aria-hidden="true">⟱</span>
+              </button>
+              <div
+                class="lore-panel"
+                id="lore-chapter-placeholder-1"
+                data-accordion-panel
+                role="region"
+                aria-hidden="true"
+              >
+                <p>Das nächste Kapitel ist in Arbeit. Halte Ausschau nach neuen Funken in den kommenden Streams.</p>
+              </div>
+            </article>
+            <article class="panel lore-item" data-accordion-item>
+              <button
+                class="lore-trigger"
+                type="button"
+                data-accordion-trigger
+                aria-expanded="false"
+                aria-controls="lore-chapter-placeholder-2"
               >
                 <span class="lore-trigger-label">Kapitel II</span>
-                <span class="lore-trigger-title">Zwischenräume &amp; Weggefährten</span>
+                <span class="lore-trigger-title">Noch verschlossen</span>
                 <span class="lore-trigger-icon" aria-hidden="true">⟱</span>
               </button>
               <div
                 class="lore-panel"
-                id="lore-chapter-2"
+                id="lore-chapter-placeholder-2"
                 data-accordion-panel
                 role="region"
                 aria-hidden="true"
               >
-                <p>
-                  Die Zwischenräume sind nicht leer – sie sind gefüllt mit Stimmen längst vergessener Sterne. Auf meinen Reisen
-                  begegnen mir Funken von Seelen, die sich dem Schatten widersetzten. Manche begleiten mich als leise Flamme, andere
-                  erscheinen nur für einen Augenblick, hinterlassen jedoch Spuren in meinen Geschichten.
-                </p>
-                <p>
-                  Aus diesen Begegnungen formt sich ein Geflecht an Erinnerungen, das ich in Streams und Lore-Schnipseln mit dir
-                  teile. Gemeinsam zeichnen wir die Karte dessen, was einmal war – und was wieder sein könnte.
-                </p>
-              </div>
-            </article>
-            <article class="panel lore-item" data-accordion-item>
-              <button
-                class="lore-trigger"
-                type="button"
-                data-accordion-trigger
-                aria-expanded="false"
-                aria-controls="lore-chapter-3"
-              >
-                <span class="lore-trigger-label">Kapitel III</span>
-                <span class="lore-trigger-title">Fragmente der Rückkehr</span>
-                <span class="lore-trigger-icon" aria-hidden="true">⟱</span>
-              </button>
-              <div
-                class="lore-panel"
-                id="lore-chapter-3"
-                data-accordion-panel
-                role="region"
-                aria-hidden="true"
-              >
-                <p>
-                  Irgendwo zwischen Mondlicht und Schatten finden sich Artefakte meiner vergangenen Macht. Sie erwachen in Momenten,
-                  in denen Resonanz entsteht – beim Erzählen, beim Lachen, beim Teilen unserer Gemeinschaft.
-                </p>
-                <p>
-                  Was heute nur als Funke leuchtet, kann morgen zur Flamme anwachsen. Bleib an meiner Seite, wenn wir weitere Kapitel
-                  schreiben und die Tore Schritt für Schritt weiter öffnen.
-                </p>
+                <p>Bald werden neue Geschichten enthüllt. Bis dahin bewahren wir die Fragmente im Schatten.</p>
               </div>
             </article>
           </div>
@@ -223,8 +241,7 @@
               title="Twitch Player – Behamot"
             ></iframe>
           </div>
-          <p class="twitch-note">Ist der Stream offline, erscheint hier der Hinweis von Twitch. Ergänze bei Bedarf die aktuelle Domain als <code>parent</code>-Parameter, damit der Player ordnungsgemäß lädt.</p>
-          <div class="offline-message" hidden>
+          <div class="twitch-status" role="status" hidden>
             <p>Aktuell offline – folge mir, um Live-Benachrichtigungen zu erhalten.</p>
             <a class="btn btn-secondary" href="https://www.twitch.tv/behamotvt" target="_blank" rel="noreferrer">Jetzt folgen</a>
           </div>
@@ -291,53 +308,254 @@
           <h2 class="section-title">Galerie &amp; Expressions</h2>
           <p class="section-lead">Ein Blick in die Facetten der Nacht – Emotionen, die flackern wie Sternenlicht.</p>
         </div>
-        <div class="gallery-grid">
-          <figure class="gallery-item">
-            <img src="../../assets/Emotes/Heart.png" alt="Behamot-Emote mit Herz" loading="lazy" />
-            <figcaption>heart</figcaption>
-          </figure>
-          <figure class="gallery-item">
-            <img src="../../assets/Emotes/Hmmm.png" alt="Behamot-Emote, nachdenklicher Blick" loading="lazy" />
-            <figcaption>hmmm</figcaption>
-          </figure>
-          <figure class="gallery-item">
-            <img src="../../assets/Emotes/Angry.png" alt="Behamot-Emote, wütender Ausdruck" loading="lazy" />
-            <figcaption>angry</figcaption>
-          </figure>
-          <figure class="gallery-item">
-            <img src="../../assets/Emotes/Glowstick.png" alt="Behamot-Emote mit Glowsticks" loading="lazy" />
-            <figcaption>glowstick</figcaption>
-          </figure>
-          <figure class="gallery-item">
-            <img src="../../assets/Emotes/WOOOW.png" alt="Behamot-Emote überrascht" loading="lazy" />
-            <figcaption>wow</figcaption>
-          </figure>
-          <figure class="gallery-item">
-            <img src="../../assets/CharakterSheet.jpg" alt="Ausschnitt aus dem offiziellen Charakter-Sheet" loading="lazy" />
-            <figcaption>character sheet</figcaption>
-          </figure>
+        <div class="gallery-categories" data-gallery>
+          <section class="gallery-category" aria-labelledby="gallery-emotes-title">
+            <div class="gallery-category__header">
+              <h3 id="gallery-emotes-title" class="gallery-category__title">Emotes</h3>
+              <p class="gallery-category__hint">Tippe für eine große Ansicht</p>
+            </div>
+            <div class="gallery-grid">
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="emotes"
+                data-gallery-src="../../assets/Emotes/Heart.png"
+                data-gallery-alt="Behamot-Emote mit Herz"
+                data-gallery-caption="Heart"
+              >
+                <img src="../../assets/Emotes/Heart.png" alt="Behamot-Emote mit Herz" loading="lazy" />
+                <span class="gallery-item__label">Heart</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="emotes"
+                data-gallery-src="../../assets/Emotes/Hmmm.png"
+                data-gallery-alt="Behamot-Emote mit nachdenklichem Blick"
+                data-gallery-caption="Hmmm"
+              >
+                <img src="../../assets/Emotes/Hmmm.png" alt="Behamot-Emote mit nachdenklichem Blick" loading="lazy" />
+                <span class="gallery-item__label">Hmmm</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="emotes"
+                data-gallery-src="../../assets/Emotes/Glowstick.png"
+                data-gallery-alt="Behamot-Emote mit Glowsticks"
+                data-gallery-caption="Glowstick"
+              >
+                <img src="../../assets/Emotes/Glowstick.png" alt="Behamot-Emote mit Glowsticks" loading="lazy" />
+                <span class="gallery-item__label">Glowstick</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="emotes"
+                data-gallery-src="../../assets/Emotes/WOOOW.png"
+                data-gallery-alt="Behamot-Emote überrascht"
+                data-gallery-caption="Wow"
+              >
+                <img src="../../assets/Emotes/WOOOW.png" alt="Behamot-Emote überrascht" loading="lazy" />
+                <span class="gallery-item__label">Wow</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="emotes"
+                data-gallery-src="../../assets/Emotes/Angry.png"
+                data-gallery-alt="Behamot-Emote mit wütendem Ausdruck"
+                data-gallery-caption="Angry"
+              >
+                <img src="../../assets/Emotes/Angry.png" alt="Behamot-Emote mit wütendem Ausdruck" loading="lazy" />
+                <span class="gallery-item__label">Angry</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="emotes"
+                data-gallery-src="../../assets/Emotes/Patpat.png"
+                data-gallery-alt="Behamot-Emote mit beruhigendem Klopfen"
+                data-gallery-caption="Patpat"
+              >
+                <img src="../../assets/Emotes/Patpat.png" alt="Behamot-Emote mit beruhigendem Klopfen" loading="lazy" />
+                <span class="gallery-item__label">Patpat</span>
+              </button>
+            </div>
+          </section>
+          <section class="gallery-category" aria-labelledby="gallery-badges-title">
+            <div class="gallery-category__header">
+              <h3 id="gallery-badges-title" class="gallery-category__title">Badges</h3>
+              <p class="gallery-category__hint">Exklusive Unterstützer-Abzeichen</p>
+            </div>
+            <div class="gallery-grid">
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="badges"
+                data-gallery-src="../../assets/badges/Month1_900.png"
+                data-gallery-alt="Abzeichen für Monat I"
+                data-gallery-caption="Monat I"
+              >
+                <img src="../../assets/badges/Month1_900.png" alt="Abzeichen für Monat I" loading="lazy" />
+                <span class="gallery-item__label">Monat I</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="badges"
+                data-gallery-src="../../assets/badges/Month3_1000px.png"
+                data-gallery-alt="Abzeichen für Monat III"
+                data-gallery-caption="Monat III"
+              >
+                <img src="../../assets/badges/Month3_1000px.png" alt="Abzeichen für Monat III" loading="lazy" />
+                <span class="gallery-item__label">Monat III</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="badges"
+                data-gallery-src="../../assets/badges/Month6_1000px.png"
+                data-gallery-alt="Abzeichen für Monat VI"
+                data-gallery-caption="Monat VI"
+              >
+                <img src="../../assets/badges/Month6_1000px.png" alt="Abzeichen für Monat VI" loading="lazy" />
+                <span class="gallery-item__label">Monat VI</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="badges"
+                data-gallery-src="../../assets/badges/Month9_1000px.png"
+                data-gallery-alt="Abzeichen für Monat IX"
+                data-gallery-caption="Monat IX"
+              >
+                <img src="../../assets/badges/Month9_1000px.png" alt="Abzeichen für Monat IX" loading="lazy" />
+                <span class="gallery-item__label">Monat IX</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="badges"
+                data-gallery-src="../../assets/badges/Month12_1000px.png"
+                data-gallery-alt="Abzeichen für Monat XII"
+                data-gallery-caption="Monat XII"
+              >
+                <img src="../../assets/badges/Month12_1000px.png" alt="Abzeichen für Monat XII" loading="lazy" />
+                <span class="gallery-item__label">Monat XII</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="badges"
+                data-gallery-src="../../assets/badges/Month18_1000px.png"
+                data-gallery-alt="Abzeichen für Monat XVIII"
+                data-gallery-caption="Monat XVIII"
+              >
+                <img src="../../assets/badges/Month18_1000px.png" alt="Abzeichen für Monat XVIII" loading="lazy" />
+                <span class="gallery-item__label">Monat XVIII</span>
+              </button>
+            </div>
+          </section>
+          <section class="gallery-category" aria-labelledby="gallery-artworks-title">
+            <div class="gallery-category__header">
+              <h3 id="gallery-artworks-title" class="gallery-category__title">Artworks</h3>
+              <p class="gallery-category__hint">Illustrationen &amp; Szenen</p>
+            </div>
+            <div class="gallery-grid">
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="artworks"
+                data-gallery-src="../../assets/CharakterSheet.jpg"
+                data-gallery-alt="Offizielles Charakter-Sheet von Behamot"
+                data-gallery-caption="Character Sheet"
+              >
+                <img src="../../assets/CharakterSheet.jpg" alt="Offizielles Charakter-Sheet von Behamot" loading="lazy" />
+                <span class="gallery-item__label">Character Sheet</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="artworks"
+                data-gallery-src="../../assets/Fiver/EmikoH_Fiverr.jpg"
+                data-gallery-alt="Artwork von EmikoH, das Behamot zeigt"
+                data-gallery-caption="Artwork von EmikoH"
+              >
+                <img src="../../assets/Fiver/EmikoH_Fiverr.jpg" alt="Artwork von EmikoH, das Behamot zeigt" loading="lazy" />
+                <span class="gallery-item__label">EmikoH</span>
+              </button>
+              <button
+                type="button"
+                class="gallery-item"
+                data-gallery-item
+                data-gallery-category="artworks"
+                data-gallery-src="../../assets/Fiver/RahmatN_Fiverr.png"
+                data-gallery-alt="Artwork von RahmatN, das Behamot zeigt"
+                data-gallery-caption="Artwork von RahmatN"
+              >
+                <img src="../../assets/Fiver/RahmatN_Fiverr.png" alt="Artwork von RahmatN, das Behamot zeigt" loading="lazy" />
+                <span class="gallery-item__label">RahmatN</span>
+              </button>
+            </div>
+          </section>
+        </div>
+        <div class="gallery-lightbox" data-gallery-lightbox hidden>
+          <div class="gallery-lightbox__overlay" data-gallery-close></div>
+          <div class="gallery-lightbox__dialog" role="dialog" aria-modal="true" aria-labelledby="gallery-lightbox-title">
+            <button type="button" class="gallery-lightbox__close" data-gallery-close aria-label="Großansicht schließen">✕</button>
+            <button type="button" class="gallery-lightbox__nav gallery-lightbox__nav--prev" data-gallery-prev aria-label="Vorheriges Motiv">
+              ⟵
+            </button>
+            <figure class="gallery-lightbox__figure">
+              <img src="" alt="" data-gallery-image loading="lazy" />
+              <figcaption id="gallery-lightbox-title" data-gallery-caption></figcaption>
+            </figure>
+            <button type="button" class="gallery-lightbox__nav gallery-lightbox__nav--next" data-gallery-next aria-label="Nächstes Motiv">
+              ⟶
+            </button>
+          </div>
         </div>
       </div>
     </section>
 
     <section id="contact" class="section" data-animate>
-      <div class="container split">
-        <div class="panel">
+      <div class="container">
+        <div class="section-heading">
           <h2 class="section-title">Kontakt &amp; Kooperationen</h2>
           <p class="section-lead">Für Anfragen, Collabs oder Booking – die Türen stehen offen.</p>
-          <ul class="contact-list">
-            <li><strong>Business-Mail:</strong> <a href="mailto:behamot007@gmail.com">behamot007@gmail.com</a></li>
-            <li><strong>Direkte DMs:</strong> <a href="https://x.com/BehamotVT" target="_blank" rel="noreferrer">@BehamotVT auf X</a></li>
-          </ul>
         </div>
-        <div class="panel">
-          <h3 class="section-subtitle">Credits &amp; Hinweise</h3>
-          <p>Illustration &amp; Charakterdesign inspiriert vom offiziellen Character-Sheet. Alle Rechte bei den jeweiligen Artists. Streaming-Inhalte © Behamot.</p>
-          <div class="legal-links">
-            <a href="#">Impressum</a>
-            <span aria-hidden="true">•</span>
-            <a href="#">Datenschutz</a>
-          </div>
+        <div class="contact-grid">
+          <article class="panel contact-card">
+            <h3 class="contact-card__title">Direkter Draht</h3>
+            <ul class="contact-list">
+              <li><strong>Business-Mail:</strong> <a href="mailto:behamot007@gmail.com">behamot007@gmail.com</a></li>
+              <li><strong>Direkte DMs:</strong> <a href="https://x.com/BehamotVT" target="_blank" rel="noreferrer">@BehamotVT auf X</a></li>
+            </ul>
+          </article>
+          <article class="panel contact-card">
+            <h3 class="contact-card__title">Credits &amp; Hinweise</h3>
+            <p>Illustration &amp; Charakterdesign inspiriert vom offiziellen Character-Sheet. Alle Rechte bei den jeweiligen Artists. Streaming-Inhalte © Behamot.</p>
+            <div class="legal-links">
+              <a href="#">Impressum</a>
+              <span aria-hidden="true">•</span>
+              <a href="#">Datenschutz</a>
+            </div>
+          </article>
         </div>
       </div>
     </section>

--- a/projects/sites/www/sites/behemoth/style.css
+++ b/projects/sites/www/sites/behemoth/style.css
@@ -200,6 +200,29 @@ h4 {
   transition: transform 240ms ease, box-shadow 240ms ease;
 }
 
+.lore-item--prolog .lore-preview {
+  padding: 0 1.75rem 1.5rem;
+  font-size: 1rem;
+  color: rgba(15, 27, 55, 0.78);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  position: relative;
+}
+
+.lore-item--prolog .lore-preview::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 40%;
+  background: linear-gradient(180deg, rgba(246, 239, 230, 0), rgba(246, 239, 230, 0.95));
+}
+
+.lore-item--prolog.is-open .lore-preview {
+  display: none;
+}
+
 .lore-item.is-open {
   box-shadow: 0 35px 70px -45px rgba(15, 27, 55, 0.8), 0 16px 35px -28px rgba(15, 27, 55, 0.6);
 }
@@ -264,6 +287,23 @@ h4 {
   overflow: hidden;
   transition: max-height 320ms ease, padding-top 320ms ease, padding-bottom 320ms ease, opacity 320ms ease;
   opacity: 0;
+}
+
+.lore-panel__content {
+  display: grid;
+  gap: 1rem;
+}
+
+.lore-panel__subhead {
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-size: 1.35rem;
+  color: var(--deep-blue);
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.lore-item--prolog .lore-panel__subhead {
+  color: rgba(15, 27, 55, 0.86);
 }
 
 .lore-panel p:last-child {
@@ -662,16 +702,24 @@ h4 {
   height: 100%;
 }
 
-.twitch-note {
-  font-size: 0.85rem;
-  color: rgba(15, 27, 55, 0.7);
+.twitch-status {
+  background: rgba(246, 239, 230, 0.95);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(198, 162, 95, 0.4);
+  display: grid;
+  gap: 0.75rem;
+  justify-items: start;
+}
+
+.twitch-status .btn {
+  width: auto;
 }
 
 .twitch-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-top: 1.5rem;
 }
 
 .twitch-actions .btn {
@@ -748,6 +796,36 @@ h4 {
   gap: 0;
 }
 
+.gallery-categories {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.gallery-category {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.gallery-category__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.gallery-category__title {
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.2rem);
+  margin: 0;
+}
+
+.gallery-category__hint {
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 27, 55, 0.6);
+}
+
 .gallery-grid {
   display: grid;
   gap: clamp(1.25rem, 3vw, 2rem);
@@ -768,31 +846,180 @@ h4 {
 .gallery-item {
   background: rgba(246, 239, 230, 0.98);
   border-radius: 1.5rem;
-  overflow: hidden;
   border: 1px solid rgba(198, 162, 95, 0.3);
   box-shadow: 0 18px 45px -30px rgba(15, 27, 55, 0.7);
+  overflow: hidden;
   position: relative;
+  padding: 0;
+  cursor: pointer;
+  display: block;
+  text-align: left;
+  transition: transform 220ms ease, box-shadow 220ms ease;
 }
 
 .gallery-item img {
+  width: 100%;
+  height: auto;
+  display: block;
   transition: transform 420ms ease;
 }
 
-.gallery-item:hover img,
-.gallery-item:focus-within img {
-  transform: scale(1.05);
-}
-
-.gallery-item figcaption {
+.gallery-item__label {
   position: absolute;
   inset: auto 0 0 0;
   padding: 0.75rem 1rem;
-  background: linear-gradient(180deg, transparent, rgba(15, 27, 55, 0.9));
+  background: linear-gradient(180deg, transparent, rgba(15, 27, 55, 0.92));
   color: var(--cream);
   font-family: "Cormorant Garamond", "Times New Roman", serif;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   font-size: 0.85rem;
+}
+
+.gallery-item:hover img,
+.gallery-item:focus-visible img {
+  transform: scale(1.05);
+}
+
+.gallery-item:focus-visible {
+  outline: 3px solid var(--gold);
+  outline-offset: 4px;
+}
+
+.gallery-lightbox {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(9, 12, 24, 0.75);
+  backdrop-filter: blur(10px);
+  z-index: 90;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.gallery-lightbox__overlay {
+  position: absolute;
+  inset: 0;
+}
+
+.gallery-lightbox__dialog {
+  position: relative;
+  max-width: min(960px, 90vw);
+  width: 100%;
+  background: rgba(15, 27, 55, 0.96);
+  border-radius: 1.75rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  display: grid;
+  grid-template-columns: auto;
+  gap: 1.25rem;
+  box-shadow: 0 40px 80px -40px rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(198, 162, 95, 0.35);
+}
+
+.gallery-lightbox__figure {
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+}
+
+.gallery-lightbox__figure img {
+  width: 100%;
+  height: auto;
+  border-radius: 1.25rem;
+  box-shadow: 0 25px 60px -35px rgba(0, 0, 0, 0.9);
+}
+
+.gallery-lightbox__figure figcaption {
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-size: 1.5rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cream);
+}
+
+.gallery-lightbox__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  border: none;
+  background: rgba(198, 162, 95, 0.16);
+  color: var(--cream);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.gallery-lightbox__nav {
+  border: none;
+  background: rgba(198, 162, 95, 0.16);
+  color: var(--cream);
+  border-radius: 999px;
+  width: 2.75rem;
+  height: 2.75rem;
+  font-size: 1.25rem;
+  cursor: pointer;
+  justify-self: center;
+}
+
+@media (min-width: 768px) {
+  .gallery-lightbox__dialog {
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+  }
+
+  .gallery-lightbox__figure {
+    grid-column: 2;
+  }
+
+  .gallery-lightbox__nav {
+    align-self: center;
+  }
+}
+
+.gallery-lightbox__nav:focus-visible,
+.gallery-lightbox__close:focus-visible {
+  outline: 3px solid var(--gold);
+  outline-offset: 3px;
+}
+
+.gallery-lightbox__nav[aria-disabled='true'] {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.contact-grid {
+  display: grid;
+  gap: clamp(2rem, 3vw, 3rem);
+}
+
+@media (min-width: 860px) {
+  .contact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
+  }
+}
+
+.contact-card {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.contact-card__title {
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.2rem);
+  color: var(--deep-blue);
+  margin: 0;
+}
+
+.contact-card p {
+  color: rgba(15, 27, 55, 0.78);
 }
 
 .contact-list {


### PR DESCRIPTION
## Summary
- update the hero CTAs to use the requested TikTok and X labels
- consolidate the lore accordion into a Prolog preview, add future chapter placeholders, and refresh the contact widgets for consistent headings
- embed the Twitch status messaging in-page and replace the gallery with category sections and a lightbox viewer with navigation

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de5efba734832f8b917498ba71114b