### PR TITLE
Add social link row and adjust spacing on Behamot page

### DIFF
--- a/projects/sites/www/sites/behemoth/index.html
+++ b/projects/sites/www/sites/behemoth/index.html
@@ -226,6 +226,43 @@
           <h2 class="section-title">Social Hub</h2>
           <p class="section-lead">Bleib verbunden – ohne eingebettete Plattformen.</p>
         </div>
+        <div class="social-links" role="group" aria-label="Soziale Plattformen">
+          <a
+            class="btn btn-social btn-discord"
+            href="https://discord.gg/pZrsSX4Tek"
+            target="_blank"
+            rel="noreferrer"
+            >Discord</a
+          >
+          <a
+            class="btn btn-social btn-youtube"
+            href="https://www.youtube.com/@Behamot"
+            target="_blank"
+            rel="noreferrer"
+            >YouTube</a
+          >
+          <a
+            class="btn btn-social btn-tiktok"
+            href="https://www.tiktok.com/@behamotvt"
+            target="_blank"
+            rel="noreferrer"
+            >TikTok</a
+          >
+          <a
+            class="btn btn-social btn-twitter"
+            href="https://x.com/BehamotVT"
+            target="_blank"
+            rel="noreferrer"
+            >X&nbsp;/&nbsp;Twitter</a
+          >
+          <a
+            class="btn btn-social btn-website"
+            href="https://www.behamot.de/"
+            target="_blank"
+            rel="noreferrer"
+            >Website</a
+          >
+        </div>
         <div class="social-grid">
           <article class="card">
             <header class="card-header">

--- a/projects/sites/www/sites/behemoth/style.css
+++ b/projects/sites/www/sites/behemoth/style.css
@@ -186,7 +186,7 @@ h4 {
 
 .lore-layout {
   display: grid;
-  gap: clamp(1.75rem, 3vw, 2.5rem);
+  gap: clamp(1.5rem, 2.8vw, 2.2rem);
 }
 
 .lore-overview {
@@ -195,7 +195,7 @@ h4 {
 
 .lore-list {
   display: grid;
-  gap: clamp(1.5rem, 2.5vw, 2rem);
+  gap: clamp(1.25rem, 2.2vw, 1.75rem);
 }
 
 .lore-item {
@@ -205,8 +205,8 @@ h4 {
 }
 
 .lore-item--prolog .lore-preview {
-  padding: 0 1.75rem 1.5rem;
-  font-size: 1rem;
+  padding: 0 1.5rem 1.25rem;
+  font-size: 0.95rem;
   color: rgba(15, 27, 55, 0.78);
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -237,8 +237,8 @@ h4 {
 
 .lore-trigger {
   display: grid;
-  gap: 0.35rem;
-  padding: clamp(1.35rem, 2.5vw, 1.75rem);
+  gap: 0.3rem;
+  padding: clamp(1.15rem, 2.3vw, 1.5rem);
   width: 100%;
   border: none;
   background: transparent;
@@ -295,7 +295,7 @@ h4 {
 
 .lore-panel__content {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .lore-panel__subhead {
@@ -744,10 +744,65 @@ h4 {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+  margin-top: 1.25rem;
 }
 
 .twitch-actions .btn {
   flex: 1 1 220px;
+}
+
+.social-links {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding: 0.35rem 0 0.5rem;
+  margin-bottom: clamp(1.5rem, 3vw, 2rem);
+  scroll-snap-type: x proximity;
+  scrollbar-width: none;
+}
+
+.social-links::-webkit-scrollbar {
+  display: none;
+}
+
+.social-links .btn {
+  flex: 0 0 auto;
+  min-width: 160px;
+  scroll-snap-align: start;
+}
+
+.btn-social {
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 16px 32px -22px rgba(15, 27, 55, 0.8);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+.btn-social:hover,
+.btn-social:focus-visible {
+  color: #fff;
+  box-shadow: 0 20px 36px -20px rgba(15, 27, 55, 0.85);
+}
+
+.btn-discord {
+  background: linear-gradient(135deg, #5865f2, #4d57d9);
+}
+
+.btn-youtube {
+  background: linear-gradient(135deg, #ff3d3d, #c60000);
+}
+
+.btn-tiktok {
+  background: linear-gradient(135deg, #111111, #ff0050 55%, #00a8c5);
+}
+
+.btn-twitter {
+  background: linear-gradient(135deg, #1d9bf0, #1474b8);
+}
+
+.btn-website {
+  background: linear-gradient(135deg, rgba(15, 27, 55, 0.95), rgba(27, 43, 85, 0.9));
 }
 
 .social-grid {


### PR DESCRIPTION
## Summary
- add a horizontal row of brand-styled social buttons to the Social Hub section
- increase the separation between the Twitch player and its action buttons for better breathing room
- fine-tune Lore spacing to keep collapsed content more compact while retaining readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea2d12530832f82eba4b6fb0babb7