### PR TITLE
Revamp Social Hub widgets

### DIFF
--- a/projects/sites/www/sites/behemoth/index.html
+++ b/projects/sites/www/sites/behemoth/index.html
@@ -226,83 +226,57 @@
           <h2 class="section-title">Social Hub</h2>
           <p class="section-lead">Bleib verbunden – ohne eingebettete Plattformen.</p>
         </div>
-        <div class="social-links" role="group" aria-label="Soziale Plattformen">
+        <div class="social-grid" role="list">
           <a
-            class="btn btn-social btn-discord"
+            class="social-widget social-widget--discord"
             href="https://discord.gg/pZrsSX4Tek"
             target="_blank"
             rel="noreferrer"
-            >Discord</a
+            role="listitem"
           >
+            <span class="social-widget__title">Discord</span>
+            <span class="social-widget__description">Community &amp; Live-Chat</span>
+          </a>
           <a
-            class="btn btn-social btn-youtube"
+            class="social-widget social-widget--youtube"
             href="https://www.youtube.com/@Behamot"
             target="_blank"
             rel="noreferrer"
-            >YouTube</a
+            role="listitem"
           >
+            <span class="social-widget__title">YouTube</span>
+            <span class="social-widget__description">Streams &amp; Premieren</span>
+          </a>
           <a
-            class="btn btn-social btn-tiktok"
+            class="social-widget social-widget--tiktok"
             href="https://www.tiktok.com/@behamotvt"
             target="_blank"
             rel="noreferrer"
-            >TikTok</a
+            role="listitem"
           >
+            <span class="social-widget__title">TikTok</span>
+            <span class="social-widget__description">Lore-Schnipsel &amp; Clips</span>
+          </a>
           <a
-            class="btn btn-social btn-twitter"
+            class="social-widget social-widget--twitter"
             href="https://x.com/BehamotVT"
             target="_blank"
             rel="noreferrer"
-            >X&nbsp;/&nbsp;Twitter</a
+            role="listitem"
           >
+            <span class="social-widget__title">X&nbsp;/&nbsp;Twitter</span>
+            <span class="social-widget__description">Updates &amp; Gedanken</span>
+          </a>
           <a
-            class="btn btn-social btn-website"
+            class="social-widget social-widget--website"
             href="https://www.behamot.de/"
             target="_blank"
             rel="noreferrer"
-            >Website</a
+            role="listitem"
           >
-        </div>
-        <div class="social-grid">
-          <article class="card">
-            <header class="card-header">
-              <h3 class="card-title">Community Highlights</h3>
-            </header>
-            <div class="card-body">
-              <p>
-                Kuratierte Momente aus Streams und Lore-Episoden erwarten dich hier künftig als kurze Zusammenfassungen und
-                Ausblicke.
-              </p>
-              <p>Bis dahin führt dich die Galerie zu den aktuellsten visuellen Eindrücken.</p>
-              <a class="btn btn-secondary" href="#gallery">Zur Galerie</a>
-            </div>
-          </article>
-          <article class="card">
-            <header class="card-header">
-              <h3 class="card-title">Stream Erinnerungen</h3>
-            </header>
-            <div class="card-body">
-              <p>
-                Verpasse keine Reise durch Licht und Schatten: Hier findest du demnächst Ankündigungen, Recaps und Hinweise auf
-                besondere Events.
-              </p>
-              <p>Schau schon jetzt im Stream-Bereich vorbei, um den aktuellen Sendeplan zu entdecken.</p>
-              <a class="btn btn-primary" href="#twitch">Zum Stream-Hub</a>
-            </div>
-          </article>
-          <article class="card">
-            <header class="card-header">
-              <h3 class="card-title">Kontakt &amp; Austausch</h3>
-            </header>
-            <div class="card-body">
-              <p>
-                Ob Kooperation, Fanpost oder Feedback – dieser Bereich bündelt künftig alle Wege, wie du mich erreichen kannst,
-                ohne externe Widgets.
-              </p>
-              <p>Nutze solange das Kontaktformular, um direkt eine Nachricht zu hinterlassen.</p>
-              <a class="btn btn-tertiary" href="#contact">Kontakt aufnehmen</a>
-            </div>
-          </article>
+            <span class="social-widget__title">Website</span>
+            <span class="social-widget__description">Portal &amp; Projekte</span>
+          </a>
         </div>
       </div>
     </section>

--- a/projects/sites/www/sites/behemoth/style.css
+++ b/projects/sites/www/sites/behemoth/style.css
@@ -785,41 +785,86 @@ h4 {
   box-shadow: 0 20px 36px -20px rgba(15, 27, 55, 0.85);
 }
 
-.btn-discord {
+.btn-discord,
+.social-widget--discord {
   background: linear-gradient(135deg, #5865f2, #4d57d9);
 }
 
-.btn-youtube {
+.btn-youtube,
+.social-widget--youtube {
   background: linear-gradient(135deg, #ff3d3d, #c60000);
 }
 
-.btn-tiktok {
+.btn-tiktok,
+.social-widget--tiktok {
   background: linear-gradient(135deg, #111111, #ff0050 55%, #00a8c5);
 }
 
-.btn-twitter {
+.btn-twitter,
+.social-widget--twitter {
   background: linear-gradient(135deg, #1d9bf0, #1474b8);
 }
 
-.btn-website {
+.btn-website,
+.social-widget--website {
   background: linear-gradient(135deg, rgba(15, 27, 55, 0.95), rgba(27, 43, 85, 0.9));
 }
 
+
 .social-grid {
   display: grid;
-  gap: clamp(1.5rem, 3vw, 2.5rem);
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: stretch;
 }
 
-@media (min-width: 640px) {
-  .social-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.social-widget {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.65rem;
+  padding: 1.35rem 1.25rem;
+  border-radius: 1.2rem;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  box-shadow: 0 16px 36px -30px rgba(15, 27, 55, 0.85);
+  position: relative;
+  isolation: isolate;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-@media (min-width: 1024px) {
-  .social-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
+.social-widget::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.social-widget:hover,
+.social-widget:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 42px -26px rgba(15, 27, 55, 0.88);
+}
+
+.social-widget:focus-visible {
+  outline: 2px solid rgba(246, 239, 230, 0.75);
+  outline-offset: 3px;
+}
+
+.social-widget__title {
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-size: 1.35rem;
+  letter-spacing: 0.01em;
+}
+
+.social-widget__description {
+  font-size: 0.95rem;
+  font-weight: 500;
+  opacity: 0.88;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- replace the social hub cards with compact platform widgets that present the five social buttons and short descriptions
- add styling for the new social widgets including responsive grid layout and hover/focus treatments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea72edda0832fa66b0648ea248e99