### PR TITLE
Fix Behemoth asset paths after folder move

### DIFF
--- a/projects/sites/www/behemoth/index.html
+++ b/projects/sites/www/behemoth/index.html
@@ -8,17 +8,17 @@
   <meta property="og:title" content="Behamot – Moth / Behemoth VTuber" />
   <meta property="og:description" content="Begleite Behamot live, entdecke Lore-Fragmente und verbinde dich auf Twitch, YouTube, TikTok und X." />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="../../assets/BehamotVtLogo.png" />
+  <meta property="og:image" content="../assets/BehamotVtLogo.png" />
   <meta property="og:url" content="https://behamot007.github.io/" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Behamot – Moth / Behemoth VTuber" />
   <meta name="twitter:description" content="Lore, Streams und Social-Highlights des Nacht-Wächters Behamot." />
-  <meta name="twitter:image" content="../../assets/BehamotVtLogo.png" />
+  <meta name="twitter:image" content="../assets/BehamotVtLogo.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-  <link rel="icon" href="../../assets/BehamotVtLogo.png" />
-  <link rel="apple-touch-icon" href="../../assets/BehamotVtLogo.png" />
+  <link rel="icon" href="../assets/BehamotVtLogo.png" />
+  <link rel="apple-touch-icon" href="../assets/BehamotVtLogo.png" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="star-sky">
@@ -26,7 +26,7 @@
   <header class="site-header" id="top">
     <div class="container nav-container">
       <div class="brand" aria-label="Behamot Logo">
-        <img src="../../assets/BehamotVtLogo.png" alt="Logo von Behamot" class="brand-mark" />
+        <img src="../assets/BehamotVtLogo.png" alt="Logo von Behamot" class="brand-mark" />
         <span class="brand-name">Behamot</span>
       </div>
       <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">
@@ -52,8 +52,8 @@
     <section id="hero" class="section hero" data-animate>
       <div class="hero-background" aria-hidden="true">
         <div class="hero-arch"></div>
-        <img src="../../assets/badges/Month12_1000px.png" alt="Vergoldetes Abzeichen – Monat XII" class="hero-ornament hero-ornament--left" data-base-transform="" loading="lazy" />
-        <img src="../../assets/badges/Month18_1000px.png" alt="Vergoldetes Abzeichen – Monat XVIII" class="hero-ornament hero-ornament--right" data-base-transform="scaleX(-1)" loading="lazy" />
+        <img src="../assets/badges/Month12_1000px.png" alt="Vergoldetes Abzeichen – Monat XII" class="hero-ornament hero-ornament--left" data-base-transform="" loading="lazy" />
+        <img src="../assets/badges/Month18_1000px.png" alt="Vergoldetes Abzeichen – Monat XVIII" class="hero-ornament hero-ornament--right" data-base-transform="scaleX(-1)" loading="lazy" />
       </div>
       <div class="container hero-content">
         <div class="hero-text">
@@ -70,7 +70,7 @@
         </div>
         <div class="hero-figure" data-parallax>
           <div class="figure-frame gold-gradient">
-            <img src="../../assets/Fullbody.png" alt="Vollkörper-Illustration von Behamot" class="figure-image" />
+            <img src="../assets/Fullbody.png" alt="Vollkörper-Illustration von Behamot" class="figure-image" />
           </div>
         </div>
       </div>
@@ -312,12 +312,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Heart.png"
+                  data-gallery-src="../assets/Emotes/Heart.png"
                   data-gallery-alt="Behamot-Emote mit Herz"
                   data-gallery-caption="Heart"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Heart.png" alt="Behamot-Emote mit Herz" loading="lazy" />
+                  <img src="../assets/Emotes/Heart.png" alt="Behamot-Emote mit Herz" loading="lazy" />
                   <span class="gallery-item__label">Heart</span>
                 </button>
                 <button
@@ -325,12 +325,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Hmmm.png"
+                  data-gallery-src="../assets/Emotes/Hmmm.png"
                   data-gallery-alt="Behamot-Emote mit nachdenklichem Blick"
                   data-gallery-caption="Hmmm"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Hmmm.png" alt="Behamot-Emote mit nachdenklichem Blick" loading="lazy" />
+                  <img src="../assets/Emotes/Hmmm.png" alt="Behamot-Emote mit nachdenklichem Blick" loading="lazy" />
                   <span class="gallery-item__label">Hmmm</span>
                 </button>
                 <button
@@ -338,12 +338,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Glowstick.png"
+                  data-gallery-src="../assets/Emotes/Glowstick.png"
                   data-gallery-alt="Behamot-Emote mit Glowsticks"
                   data-gallery-caption="Glowstick"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Glowstick.png" alt="Behamot-Emote mit Glowsticks" loading="lazy" />
+                  <img src="../assets/Emotes/Glowstick.png" alt="Behamot-Emote mit Glowsticks" loading="lazy" />
                   <span class="gallery-item__label">Glowstick</span>
                 </button>
                 <button
@@ -351,12 +351,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/WOOOW.png"
+                  data-gallery-src="../assets/Emotes/WOOOW.png"
                   data-gallery-alt="Behamot-Emote überrascht"
                   data-gallery-caption="Wow"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/WOOOW.png" alt="Behamot-Emote überrascht" loading="lazy" />
+                  <img src="../assets/Emotes/WOOOW.png" alt="Behamot-Emote überrascht" loading="lazy" />
                   <span class="gallery-item__label">Wow</span>
                 </button>
                 <button
@@ -364,12 +364,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Angry.png"
+                  data-gallery-src="../assets/Emotes/Angry.png"
                   data-gallery-alt="Behamot-Emote mit wütendem Ausdruck"
                   data-gallery-caption="Angry"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Angry.png" alt="Behamot-Emote mit wütendem Ausdruck" loading="lazy" />
+                  <img src="../assets/Emotes/Angry.png" alt="Behamot-Emote mit wütendem Ausdruck" loading="lazy" />
                   <span class="gallery-item__label">Angry</span>
                 </button>
                 <button
@@ -377,12 +377,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Patpat.png"
+                  data-gallery-src="../assets/Emotes/Patpat.png"
                   data-gallery-alt="Behamot-Emote mit beruhigendem Klopfen"
                   data-gallery-caption="Patpat"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Patpat.png" alt="Behamot-Emote mit beruhigendem Klopfen" loading="lazy" />
+                  <img src="../assets/Emotes/Patpat.png" alt="Behamot-Emote mit beruhigendem Klopfen" loading="lazy" />
                   <span class="gallery-item__label">Patpat</span>
                 </button>
                 <button
@@ -390,12 +390,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Crying.png"
+                  data-gallery-src="../assets/Emotes/Crying.png"
                   data-gallery-alt="Behamot-Emote mit traurigem Blick"
                   data-gallery-caption="Crying"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Crying.png" alt="Behamot-Emote mit traurigem Blick" loading="lazy" />
+                  <img src="../assets/Emotes/Crying.png" alt="Behamot-Emote mit traurigem Blick" loading="lazy" />
                   <span class="gallery-item__label">Crying</span>
                 </button>
                 <button
@@ -403,12 +403,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Hahaha.png"
+                  data-gallery-src="../assets/Emotes/Hahaha.png"
                   data-gallery-alt="Behamot-Emote lacht herzlich"
                   data-gallery-caption="Hahaha"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Hahaha.png" alt="Behamot-Emote lacht herzlich" loading="lazy" />
+                  <img src="../assets/Emotes/Hahaha.png" alt="Behamot-Emote lacht herzlich" loading="lazy" />
                   <span class="gallery-item__label">Hahaha</span>
                 </button>
                 <button
@@ -416,12 +416,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/HUH.png"
+                  data-gallery-src="../assets/Emotes/HUH.png"
                   data-gallery-alt="Behamot-Emote mit verwundertem Gesichtsausdruck"
                   data-gallery-caption="HUH"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/HUH.png" alt="Behamot-Emote mit verwundertem Gesichtsausdruck" loading="lazy" />
+                  <img src="../assets/Emotes/HUH.png" alt="Behamot-Emote mit verwundertem Gesichtsausdruck" loading="lazy" />
                   <span class="gallery-item__label">HUH</span>
                 </button>
                 <button
@@ -429,12 +429,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Hi.png"
+                  data-gallery-src="../assets/Emotes/Hi.png"
                   data-gallery-alt="Behamot-Emote winkt freundlich"
                   data-gallery-caption="Hi"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Hi.png" alt="Behamot-Emote winkt freundlich" loading="lazy" />
+                  <img src="../assets/Emotes/Hi.png" alt="Behamot-Emote winkt freundlich" loading="lazy" />
                   <span class="gallery-item__label">Hi</span>
                 </button>
                 <button
@@ -442,12 +442,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Lurk.png"
+                  data-gallery-src="../assets/Emotes/Lurk.png"
                   data-gallery-alt="Behamot-Emote späht neugierig"
                   data-gallery-caption="Lurk"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Lurk.png" alt="Behamot-Emote späht neugierig" loading="lazy" />
+                  <img src="../assets/Emotes/Lurk.png" alt="Behamot-Emote späht neugierig" loading="lazy" />
                   <span class="gallery-item__label">Lurk</span>
                 </button>
                 <button
@@ -455,12 +455,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="emotes"
-                  data-gallery-src="../../assets/Emotes/Moth_Heart.png"
+                  data-gallery-src="../assets/Emotes/Moth_Heart.png"
                   data-gallery-alt="Behamot-Emote als Motte mit Herz"
                   data-gallery-caption="Moth Heart"
                   role="listitem"
                 >
-                  <img src="../../assets/Emotes/Moth_Heart.png" alt="Behamot-Emote als Motte mit Herz" loading="lazy" />
+                  <img src="../assets/Emotes/Moth_Heart.png" alt="Behamot-Emote als Motte mit Herz" loading="lazy" />
                   <span class="gallery-item__label">Moth Heart</span>
                 </button>
               </div>
@@ -498,12 +498,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="badges"
-                  data-gallery-src="../../assets/badges/Month1_900.png"
+                  data-gallery-src="../assets/badges/Month1_900.png"
                   data-gallery-alt="Abzeichen für Monat I"
                   data-gallery-caption="Monat I"
                   role="listitem"
                 >
-                  <img src="../../assets/badges/Month1_900.png" alt="Abzeichen für Monat I" loading="lazy" />
+                  <img src="../assets/badges/Month1_900.png" alt="Abzeichen für Monat I" loading="lazy" />
                   <span class="gallery-item__label">Monat I</span>
                 </button>
                 <button
@@ -511,12 +511,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="badges"
-                  data-gallery-src="../../assets/badges/Month3_1000px.png"
+                  data-gallery-src="../assets/badges/Month3_1000px.png"
                   data-gallery-alt="Abzeichen für Monat III"
                   data-gallery-caption="Monat III"
                   role="listitem"
                 >
-                  <img src="../../assets/badges/Month3_1000px.png" alt="Abzeichen für Monat III" loading="lazy" />
+                  <img src="../assets/badges/Month3_1000px.png" alt="Abzeichen für Monat III" loading="lazy" />
                   <span class="gallery-item__label">Monat III</span>
                 </button>
                 <button
@@ -524,12 +524,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="badges"
-                  data-gallery-src="../../assets/badges/Month6_1000px.png"
+                  data-gallery-src="../assets/badges/Month6_1000px.png"
                   data-gallery-alt="Abzeichen für Monat VI"
                   data-gallery-caption="Monat VI"
                   role="listitem"
                 >
-                  <img src="../../assets/badges/Month6_1000px.png" alt="Abzeichen für Monat VI" loading="lazy" />
+                  <img src="../assets/badges/Month6_1000px.png" alt="Abzeichen für Monat VI" loading="lazy" />
                   <span class="gallery-item__label">Monat VI</span>
                 </button>
                 <button
@@ -537,12 +537,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="badges"
-                  data-gallery-src="../../assets/badges/Month9_1000px.png"
+                  data-gallery-src="../assets/badges/Month9_1000px.png"
                   data-gallery-alt="Abzeichen für Monat IX"
                   data-gallery-caption="Monat IX"
                   role="listitem"
                 >
-                  <img src="../../assets/badges/Month9_1000px.png" alt="Abzeichen für Monat IX" loading="lazy" />
+                  <img src="../assets/badges/Month9_1000px.png" alt="Abzeichen für Monat IX" loading="lazy" />
                   <span class="gallery-item__label">Monat IX</span>
                 </button>
                 <button
@@ -550,12 +550,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="badges"
-                  data-gallery-src="../../assets/badges/Month12_1000px.png"
+                  data-gallery-src="../assets/badges/Month12_1000px.png"
                   data-gallery-alt="Abzeichen für Monat XII"
                   data-gallery-caption="Monat XII"
                   role="listitem"
                 >
-                  <img src="../../assets/badges/Month12_1000px.png" alt="Abzeichen für Monat XII" loading="lazy" />
+                  <img src="../assets/badges/Month12_1000px.png" alt="Abzeichen für Monat XII" loading="lazy" />
                   <span class="gallery-item__label">Monat XII</span>
                 </button>
                 <button
@@ -563,12 +563,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="badges"
-                  data-gallery-src="../../assets/badges/Month18_1000px.png"
+                  data-gallery-src="../assets/badges/Month18_1000px.png"
                   data-gallery-alt="Abzeichen für Monat XVIII"
                   data-gallery-caption="Monat XVIII"
                   role="listitem"
                 >
-                  <img src="../../assets/badges/Month18_1000px.png" alt="Abzeichen für Monat XVIII" loading="lazy" />
+                  <img src="../assets/badges/Month18_1000px.png" alt="Abzeichen für Monat XVIII" loading="lazy" />
                   <span class="gallery-item__label">Monat XVIII</span>
                 </button>
               </div>
@@ -606,12 +606,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="artworks"
-                  data-gallery-src="../../assets/CharakterSheet.jpg"
+                  data-gallery-src="../assets/CharakterSheet.jpg"
                   data-gallery-alt="Offizielles Charakter-Sheet von Behamot"
                   data-gallery-caption="Character Sheet"
                   role="listitem"
                 >
-                  <img src="../../assets/CharakterSheet.jpg" alt="Offizielles Charakter-Sheet von Behamot" loading="lazy" />
+                  <img src="../assets/CharakterSheet.jpg" alt="Offizielles Charakter-Sheet von Behamot" loading="lazy" />
                   <span class="gallery-item__label">Character Sheet</span>
                 </button>
                 <button
@@ -619,12 +619,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="artworks"
-                  data-gallery-src="../../assets/Fiver/EmikoH_Fiverr.jpg"
+                  data-gallery-src="../assets/Fiver/EmikoH_Fiverr.jpg"
                   data-gallery-alt="Artwork von EmikoH, das Behamot zeigt"
                   data-gallery-caption="Artwork von EmikoH"
                   role="listitem"
                 >
-                  <img src="../../assets/Fiver/EmikoH_Fiverr.jpg" alt="Artwork von EmikoH, das Behamot zeigt" loading="lazy" />
+                  <img src="../assets/Fiver/EmikoH_Fiverr.jpg" alt="Artwork von EmikoH, das Behamot zeigt" loading="lazy" />
                   <span class="gallery-item__label">EmikoH</span>
                 </button>
                 <button
@@ -632,12 +632,12 @@
                   class="gallery-item"
                   data-gallery-item
                   data-gallery-category="artworks"
-                  data-gallery-src="../../assets/Fiver/RahmatN_Fiverr.png"
+                  data-gallery-src="../assets/Fiver/RahmatN_Fiverr.png"
                   data-gallery-alt="Artwork von RahmatN, das Behamot zeigt"
                   data-gallery-caption="Artwork von RahmatN"
                   role="listitem"
                 >
-                  <img src="../../assets/Fiver/RahmatN_Fiverr.png" alt="Artwork von RahmatN, das Behamot zeigt" loading="lazy" />
+                  <img src="../assets/Fiver/RahmatN_Fiverr.png" alt="Artwork von RahmatN, das Behamot zeigt" loading="lazy" />
                   <span class="gallery-item__label">RahmatN</span>
                 </button>
               </div>
@@ -704,7 +704,7 @@
       <div class="star-divider" aria-hidden="true"></div>
       <div class="footer-content">
         <div class="footer-brand">
-          <img src="../../assets/BehamotVtLogo.png" alt="Behamot Zeichen" />
+          <img src="../assets/BehamotVtLogo.png" alt="Behamot Zeichen" />
           <span>Behamot</span>
         </div>
         <div class="footer-links">


### PR DESCRIPTION
## Summary
- update the Behemoth landing page to reference the relocated `/assets` directory under `projects/sites/www`
- ensure all hero, gallery and footer images resolve using the new relative paths

## Testing
- python -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68dfff775500832f8e6db76970fd1171