### PR TITLE
Add Twitch chat controller backend and UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,12 @@ SPOTIFY_CLIENT_SECRET=
 # TLS automation
 CERTBOT_EMAIL=admin@behamot.de
 CERTBOT_DOMAINS=dev.behamot.de,www.behamot.de
+
+# Twitch Chat Controller
+TWITCH_API_PASSWORD=
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+TWITCH_REDIRECT_URI=https://www.behamot.de/services/twitch-bot/oauth/callback
+TWITCH_BOT_USERNAME=
+TWITCH_BOT_OAUTH_TOKEN=oauth:...
+TWITCH_DEFAULT_CHANNEL=

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Eine vollständige Zielstruktur inklusive Naming-Konventionen und README-Templat
 ## Verzeichnisstruktur
 
 - `projects/dev-backend/anime-dataset/`: Node.js-Backend-Service für Spotify-/OpenAI-Bridging sowie den Anime-Datensatz (ohne Frontend-Verwaltung).
+- `projects/dev-backend/twitch-chat-controller/`: Express-Service zum Steuern eines Twitch-Chats inkl. OAuth-Brücke und SSE-Stream.
 - `Dockerfile.frontend`: Build-Anleitung für das nginx-Frontend.
 - `projects/dev-backend/anime-dataset/Dockerfile`: Build-Anleitung für den Backend-Service.
 - `docker-compose.yml`: Definition der Services, Netzwerke und Volumes.
@@ -48,13 +49,14 @@ BACKEND_API_TOKEN=geheim docker compose up -d --build
 docker compose logs -f backend
 ```
 
-Der Befehl `docker compose up -d --build` baut beide Images (`backend`, `frontend`), erstellt die Netzwerke (`internal`, `public`) und startet die Container im Hintergrund. Das Frontend ist anschließend unter `http://localhost:8080` erreichbar. Interne Aufrufe an `/api/*` werden automatisch an den Backend-Service weitergeleitet.
+Der Befehl `docker compose up -d --build` baut alle Images (`backend`, `frontend`, `twitch-controller`), erstellt die Netzwerke (`internal`, `public`) und startet die Container im Hintergrund. Das Frontend ist anschließend unter `http://localhost:8080` erreichbar. Interne Aufrufe an `/api/*` werden automatisch an den passenden Backend-Service weitergeleitet.
 
 ### Frontend ↔ Backend Zusammenspiel
 
 - Der Dev-Bereich (`projects/sites/dev/`, inkl. „Anime Dataset Verwaltung“) erwartet, dass der Backend-Einstiegspunkt unter `/api` erreichbar ist. Für containerisierte Deployments wird dies über das Compose-Environment `FRONTEND_BACKEND_API_BASE` (Default: `http://backend:3000`) sowie die nginx-Proxy-Regeln aus `docker/nginx/default.conf` realisiert.
 - In lokalen Szenarien ohne Docker kann die Variable `BACKEND_API_BASE` beispielsweise per `.env` auf `http://localhost:3000` gesetzt werden; der Dev-Server muss anschließend Anfragen an diesen Host weiterreichen.
 - Statische Assets werden ausschließlich vom Frontend ausgeliefert. Das Backend konzentriert sich auf JSON-APIs (Spotify, OpenAI, Dataset-CRUD) und stellt keine eigene `public/`-Oberfläche mehr bereit.
+- Der Twitch Chat Controller wird über `/api/twitch/*` angesprochen und innerhalb des Stacks automatisch an den neuen Service `twitch-controller` weitergeleitet. Die Oberfläche liegt unter `projects/sites/dev/services/twitch-bot`.
 
 ### Datenpersistenz
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     image: behamot007/anime-frontend:latest
     depends_on:
       - backend
+      - twitch-controller
     environment:
       - BACKEND_API_BASE=${FRONTEND_BACKEND_API_BASE:-http://backend:3000}
       - DEV_SERVER_NAME=${DEV_SERVER_NAME:-dev.localhost}
@@ -57,6 +58,27 @@ services:
     networks:
       - internal
       - public
+
+  twitch-controller:
+    build:
+      context: ./projects/dev-backend/twitch-chat-controller
+    image: behamot007/twitch-chat-controller:latest
+    environment:
+      - NODE_ENV=production
+      - PORT=4010
+      - TWITCH_API_PASSWORD=${TWITCH_API_PASSWORD:-}
+      - TWITCH_CLIENT_ID=${TWITCH_CLIENT_ID:-}
+      - TWITCH_CLIENT_SECRET=${TWITCH_CLIENT_SECRET:-}
+      - TWITCH_REDIRECT_URI=${TWITCH_REDIRECT_URI:-https://www.behamot.de/services/twitch-bot/oauth/callback}
+      - TWITCH_BOT_USERNAME=${TWITCH_BOT_USERNAME:-}
+      - TWITCH_BOT_OAUTH_TOKEN=${TWITCH_BOT_OAUTH_TOKEN:-}
+      - TWITCH_DEFAULT_CHANNEL=${TWITCH_DEFAULT_CHANNEL:-}
+    networks:
+      - internal
+    expose:
+      - "4010"
+    ports:
+      - "4010:4010"
 
   certbot:
     image: certbot/certbot:latest

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -17,6 +17,15 @@ server {
         try_files $uri =404;
     }
 
+    location /api/twitch/ {
+        proxy_pass http://twitch-controller:4010;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api/ {
         proxy_pass http://backend:3000;
         proxy_http_version 1.1;

--- a/projects/dev-backend/README.md
+++ b/projects/dev-backend/README.md
@@ -47,3 +47,7 @@ docker compose logs -f backend
 ```
 
 Der Datensatz liegt standardmäßig unter `dataset/characters.jsonl`. Über das bind-mount `./projects/dev-backend/anime-dataset/dataset:/app/dataset` bleiben Änderungen lokal erhalten.
+
+## Zusätzliche Services
+
+- `twitch-chat-controller/`: Separates Express-Backend, das einen Twitch-Bot verwaltet, Chatnachrichten per SSE streamt und einen OAuth-Test-Flow bereitstellt. Die zugehörige Oberfläche befindet sich unter `projects/sites/dev/services/twitch-bot`.

--- a/projects/dev-backend/twitch-chat-controller/.env.example
+++ b/projects/dev-backend/twitch-chat-controller/.env.example
@@ -1,0 +1,11 @@
+# Pflichtparameter
+TWITCH_API_PASSWORD=change-me
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+TWITCH_REDIRECT_URI=https://www.behamot.de/services/twitch-bot/oauth/callback
+TWITCH_BOT_USERNAME=
+TWITCH_BOT_OAUTH_TOKEN=oauth:...
+TWITCH_DEFAULT_CHANNEL=
+
+# Optional
+PORT=4010

--- a/projects/dev-backend/twitch-chat-controller/README.md
+++ b/projects/dev-backend/twitch-chat-controller/README.md
@@ -1,0 +1,62 @@
+# Twitch Chat Controller Backend
+
+Dieser Service stellt eine abgesicherte API bereit, um einen Twitch-Chat über einen Bot-Account zu beobachten und Nachrichten zu versenden. Die Kommunikation mit Twitch erfolgt ausschließlich serverseitig über `tmi.js`. Eine zusätzliche Passwortschicht verhindert unbefugte Nutzung der Schnittstellen.
+
+## Features
+
+- Server-Sent-Events Stream für Chatnachrichten (inkl. Outgoing-Messages des Bots)
+- Versand von Chatnachrichten über einen hinterlegten Bot-Account
+- OAuth-Autorisierungs-Flow zur Erzeugung von Test-Tokens (mit Popup-Rückmeldung)
+- Konfigurierbares API-Passwort, das sowohl von der Web-Oberfläche als auch von externen Clients abgefragt wird
+
+## Schnellstart
+
+```bash
+cd projects/dev-backend/twitch-chat-controller
+npm install
+cp .env.example .env
+# .env mit eigenen Zugangsdaten füllen
+npm start
+```
+
+Der Server lauscht standardmäßig auf Port `4010`. Über einen Reverse-Proxy (z. B. nginx) kann der Pfad `/api/twitch/*` an diesen Service weitergeleitet werden.
+
+## Umgebungsvariablen
+
+| Variable | Beschreibung |
+|----------|--------------|
+| `PORT` | (Optional) Abweichender Port für das Express-Backend (Standard: 4010). |
+| `TWITCH_API_PASSWORD` | Obligatorisches Passwort, das jede Anfrage (außer dem OAuth-Callback) mitliefern muss. |
+| `TWITCH_CLIENT_ID` | Client-ID der Twitch Application für OAuth. |
+| `TWITCH_CLIENT_SECRET` | Client-Secret der Twitch Application für OAuth. |
+| `TWITCH_REDIRECT_URI` | Redirect-URL, die in der Twitch Application hinterlegt ist (z. B. `https://www.behamot.de/services/twitch-bot/oauth/callback`). |
+| `TWITCH_BOT_USERNAME` | Benutzername des Bot-Accounts, der den Chat steuert. |
+| `TWITCH_BOT_OAUTH_TOKEN` | OAuth-Token im Format `oauth:...`, das vom Bot-Account generiert wurde. |
+| `TWITCH_DEFAULT_CHANNEL` | (Optional) Kanal, der automatisch beim Start betreten werden soll. |
+
+> Hinweis: Das API-Passwort muss im Frontend eingegeben werden. Für Streaming-Endpunkte kann das Passwort als `apiPassword` Query-Parameter gesetzt werden, damit EventSource-Verbindungen funktionieren.
+
+## API-Überblick
+
+Alle Routen (bis auf den OAuth-Callback) verlangen das korrekte Passwort, entweder über den `Authorization: Bearer <passwort>` Header, den Header `x-api-password` oder über den Query-Parameter `apiPassword`.
+
+| Methode | Route | Beschreibung |
+|---------|-------|--------------|
+| `GET` | `/api/twitch/status` | Statusinformationen zum Bot und der Twitch-Verbindung. |
+| `GET` | `/api/twitch/config` | Liefert Standardkonfigurationen (Redirect-URL, Default-Channel, empfohlene Scopes). |
+| `GET` | `/api/twitch/chat/stream?channel=<name>&apiPassword=<pw>` | Server-Sent-Events Stream der Chatnachrichten eines Kanals. |
+| `GET` | `/api/twitch/chat/history?channel=<name>` | Liefert die letzten 50 gespeicherten Nachrichten. |
+| `POST` | `/api/twitch/chat/send` | Sendet eine Nachricht in den angegebenen Channel. |
+| `GET` | `/api/twitch/oauth/authorize` | Erstellt eine OAuth-Login-URL samt State. |
+| `GET` | `/api/twitch/oauth/callback` | Ziel-URL für Twitch nach erfolgreichem Login. Antwortet mit einer HTML-Seite, die Tokens an das ursprüngliche Fenster meldet. |
+
+## Frontend-Integration
+
+Die zugehörige Weboberfläche liegt unter `projects/sites/dev/services/twitch-bot`. Sie fragt das Passwort ab, öffnet bei Bedarf den OAuth-Login und verbindet sich anschließend via SSE mit dem gewünschten Kanal. Nachrichten können direkt aus dem Browser gesendet werden und erscheinen inklusive Bot-Markierung im Verlauf.
+
+Stelle sicher, dass der Reverse-Proxy die Pfade
+
+- `GET /api/twitch/*`
+- `POST /api/twitch/*`
+
+an diesen Service weiterleitet. Die OAuth-Redirect-URL muss identisch zur Konfiguration in der Twitch Developer Console sein und auf die öffentlich erreichbare Domain (`https://www.behamot.de/...`) zeigen.

--- a/projects/dev-backend/twitch-chat-controller/package.json
+++ b/projects/dev-backend/twitch-chat-controller/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "twitch-chat-controller",
+  "version": "0.1.0",
+  "description": "Backend-Service zum Steuern eines Twitch-Chats über einen Bot-Account",
+  "type": "module",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "tmi.js": "^1.8.5"
+  }
+}

--- a/projects/dev-backend/twitch-chat-controller/server.js
+++ b/projects/dev-backend/twitch-chat-controller/server.js
@@ -1,0 +1,433 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import axios from 'axios';
+import tmi from 'tmi.js';
+import crypto from 'node:crypto';
+
+const {
+  PORT = 4010,
+  TWITCH_CLIENT_ID,
+  TWITCH_CLIENT_SECRET,
+  TWITCH_REDIRECT_URI,
+  TWITCH_BOT_USERNAME,
+  TWITCH_BOT_OAUTH_TOKEN,
+  TWITCH_DEFAULT_CHANNEL,
+  TWITCH_API_PASSWORD
+} = process.env;
+
+if (!TWITCH_API_PASSWORD) {
+  console.warn('[twitch-chat-controller] WARN: TWITCH_API_PASSWORD ist nicht gesetzt. Ohne Passwort wird jede Anfrage abgelehnt.');
+}
+
+if (!TWITCH_CLIENT_ID || !TWITCH_CLIENT_SECRET || !TWITCH_REDIRECT_URI) {
+  console.warn('[twitch-chat-controller] WARN: OAuth-Konfiguration ist unvollständig. /api/twitch/oauth/* wird nicht funktionieren.');
+}
+
+if (!TWITCH_BOT_USERNAME || !TWITCH_BOT_OAUTH_TOKEN) {
+  console.warn('[twitch-chat-controller] WARN: Bot-Zugangsdaten fehlen. Chat-Verbindungen können nicht aufgebaut werden.');
+}
+
+const app = express();
+app.use(cors());
+app.use(express.json({ limit: '256kb' }));
+
+function normalizeChannelName(channel) {
+  if (!channel) return '';
+  return channel.replace(/^#/, '').trim().toLowerCase();
+}
+
+const joinedChannels = new Set();
+const channelContexts = new Map();
+const oauthStates = new Map();
+let chatClientReady = false;
+
+function getOrCreateChannelContext(channel) {
+  const normalized = normalizeChannelName(channel);
+  if (!channelContexts.has(normalized)) {
+    channelContexts.set(normalized, {
+      channel: normalized,
+      watchers: new Set(),
+      backlog: [],
+      lastId: 0
+    });
+  }
+  return channelContexts.get(normalized);
+}
+
+function serializeEvent(event) {
+  return `id: ${event.id}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+function pushBacklog(context, payload) {
+  context.lastId += 1;
+  const event = { id: context.lastId, ...payload };
+  context.backlog.push(event);
+  if (context.backlog.length > 100) {
+    context.backlog.shift();
+  }
+  return event;
+}
+
+function broadcastToChannel(channel, payload) {
+  const context = getOrCreateChannelContext(channel);
+  const event = pushBacklog(context, payload);
+  const serialized = serializeEvent(event);
+  context.watchers.forEach(res => {
+    res.write(serialized);
+  });
+}
+
+async function ensureChatClientConnected() {
+  if (!TWITCH_BOT_USERNAME || !TWITCH_BOT_OAUTH_TOKEN) {
+    throw new Error('Bot Zugangsdaten sind nicht vollständig gesetzt.');
+  }
+  if (chatClientReady) return;
+  if (ensureChatClientConnected._connecting) {
+    return ensureChatClientConnected._connecting;
+  }
+  const client = createChatClient();
+  ensureChatClientConnected._client = client;
+  const promise = client.connect()
+    .then(() => {
+      chatClientReady = true;
+      console.log('[twitch-chat-controller] Chat-Client verbunden.');
+      return client;
+    })
+    .catch(error => {
+      console.error('[twitch-chat-controller] Chat-Client konnte nicht verbunden werden:', error);
+      throw error;
+    })
+    .finally(() => {
+      ensureChatClientConnected._connecting = null;
+    });
+  ensureChatClientConnected._connecting = promise;
+  return promise;
+}
+
+function createChatClient() {
+  const client = new tmi.Client({
+    options: { debug: false },
+    connection: { reconnect: true, secure: true },
+    identity: {
+      username: TWITCH_BOT_USERNAME,
+      password: TWITCH_BOT_OAUTH_TOKEN
+    },
+    channels: TWITCH_DEFAULT_CHANNEL
+      ? [`#${normalizeChannelName(TWITCH_DEFAULT_CHANNEL)}`]
+      : []
+  });
+
+  client.on('connected', (_address, _port) => {
+    chatClientReady = true;
+    console.log('[twitch-chat-controller] Mit Twitch verbunden.');
+  });
+
+  client.on('reconnect', () => {
+    console.log('[twitch-chat-controller] Versuche Twitch-Reconnect...');
+  });
+
+  client.on('disconnected', reason => {
+    chatClientReady = false;
+    console.warn('[twitch-chat-controller] Twitch-Verbindung getrennt:', reason);
+  });
+
+  client.on('message', (channel, tags, message, self) => {
+    if (self) return;
+    const normalized = normalizeChannelName(channel);
+    const payload = {
+      type: 'message',
+      channel: normalized,
+      userId: tags['user-id'] || null,
+      username: tags['display-name'] || tags.username,
+      message,
+      color: tags.color || null,
+      badges: tags.badges || null,
+      timestamp: new Date().toISOString()
+    };
+    broadcastToChannel(normalized, payload);
+  });
+
+  client.on('join', (channel, username, self) => {
+    if (!self) return;
+    const normalized = normalizeChannelName(channel);
+    broadcastToChannel(normalized, {
+      type: 'system',
+      channel: normalized,
+      message: `Bot ist dem Channel #${normalized} beigetreten.`,
+      timestamp: new Date().toISOString()
+    });
+  });
+
+  client.on('part', (channel, username, self) => {
+    if (!self) return;
+    const normalized = normalizeChannelName(channel);
+    joinedChannels.delete(normalized);
+    broadcastToChannel(normalized, {
+      type: 'system',
+      channel: normalized,
+      message: `Bot hat Channel #${normalized} verlassen.`,
+      timestamp: new Date().toISOString()
+    });
+  });
+
+  client.on('connected', async () => {
+    if (TWITCH_DEFAULT_CHANNEL) {
+      const normalized = normalizeChannelName(TWITCH_DEFAULT_CHANNEL);
+      joinedChannels.add(normalized);
+    }
+  });
+
+  return client;
+}
+
+function getChatClient() {
+  return ensureChatClientConnected._client;
+}
+
+function getPasswordFromRequest(req) {
+  const header = req.get('x-api-password');
+  if (header) return header;
+  const auth = req.get('authorization');
+  if (auth && auth.toLowerCase().startsWith('bearer ')) {
+    return auth.slice(7);
+  }
+  if (req.query && (req.query.apiPassword || req.query.password)) {
+    return req.query.apiPassword || req.query.password;
+  }
+  if (req.body && typeof req.body === 'object') {
+    if (req.body.apiPassword) return req.body.apiPassword;
+    if (req.body.password) return req.body.password;
+  }
+  return null;
+}
+
+function isPublicRoute(req) {
+  return req.path === '/api/twitch/oauth/callback';
+}
+
+app.use((req, res, next) => {
+  if (isPublicRoute(req)) {
+    return next();
+  }
+  if (!TWITCH_API_PASSWORD) {
+    return res.status(500).json({ error: 'API-Passwort ist im Backend nicht konfiguriert.' });
+  }
+  const provided = getPasswordFromRequest(req);
+  if (provided !== TWITCH_API_PASSWORD) {
+    return res.status(401).json({ error: 'Ungültiges API-Passwort.' });
+  }
+  return next();
+});
+
+app.get('/api/twitch/status', (_req, res) => {
+  res.json({
+    ready: chatClientReady,
+    joinedChannels: Array.from(joinedChannels),
+    defaultChannel: TWITCH_DEFAULT_CHANNEL ? normalizeChannelName(TWITCH_DEFAULT_CHANNEL) : null,
+    hasBotCredentials: Boolean(TWITCH_BOT_USERNAME && TWITCH_BOT_OAUTH_TOKEN),
+    oauthConfigured: Boolean(TWITCH_CLIENT_ID && TWITCH_CLIENT_SECRET && TWITCH_REDIRECT_URI)
+  });
+});
+
+app.get('/api/twitch/config', (_req, res) => {
+  res.json({
+    defaultChannel: TWITCH_DEFAULT_CHANNEL ? normalizeChannelName(TWITCH_DEFAULT_CHANNEL) : '',
+    redirectUri: TWITCH_REDIRECT_URI || '',
+    clientId: TWITCH_CLIENT_ID || '',
+    scopes: ['chat:read', 'chat:edit', 'channel:moderate']
+  });
+});
+
+app.get('/api/twitch/chat/stream', async (req, res) => {
+  const channel = normalizeChannelName(req.query.channel);
+  if (!channel) {
+    return res.status(400).json({ error: 'Parameter "channel" fehlt.' });
+  }
+  try {
+    await ensureChatClientConnected();
+  } catch (error) {
+    return res.status(500).json({ error: 'Twitch-Client konnte nicht verbunden werden.', details: error.message });
+  }
+  const client = getChatClient();
+  if (!joinedChannels.has(channel)) {
+    try {
+      await client.join(`#${channel}`);
+      joinedChannels.add(channel);
+    } catch (error) {
+      return res.status(500).json({ error: `Channel #${channel} konnte nicht betreten werden.`, details: error.message });
+    }
+  }
+  const context = getOrCreateChannelContext(channel);
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive'
+  });
+  res.write('\n');
+
+  context.watchers.add(res);
+  context.backlog.forEach(event => {
+    res.write(serializeEvent(event));
+  });
+
+  req.on('close', () => {
+    context.watchers.delete(res);
+  });
+});
+
+app.get('/api/twitch/chat/history', (req, res) => {
+  const channel = normalizeChannelName(req.query.channel);
+  if (!channel) {
+    return res.status(400).json({ error: 'Parameter "channel" fehlt.' });
+  }
+  const context = getOrCreateChannelContext(channel);
+  res.json({ messages: context.backlog.slice(-50) });
+});
+
+app.post('/api/twitch/chat/send', async (req, res) => {
+  const channel = normalizeChannelName(req.body?.channel || TWITCH_DEFAULT_CHANNEL);
+  const message = req.body?.message;
+  if (!channel) {
+    return res.status(400).json({ error: 'Channel fehlt in der Anfrage.' });
+  }
+  if (!message || typeof message !== 'string' || !message.trim()) {
+    return res.status(400).json({ error: 'Nachricht ist leer.' });
+  }
+  try {
+    await ensureChatClientConnected();
+    const client = getChatClient();
+    if (!joinedChannels.has(channel)) {
+      await client.join(`#${channel}`);
+      joinedChannels.add(channel);
+    }
+    await client.say(`#${channel}`, message.trim());
+    broadcastToChannel(channel, {
+      type: 'outgoing',
+      channel,
+      username: TWITCH_BOT_USERNAME,
+      message: message.trim(),
+      timestamp: new Date().toISOString()
+    });
+    res.json({ success: true });
+  } catch (error) {
+    console.error('[twitch-chat-controller] Nachricht konnte nicht gesendet werden:', error);
+    res.status(500).json({ error: 'Nachricht konnte nicht gesendet werden.', details: error.message });
+  }
+});
+
+app.get('/api/twitch/oauth/authorize', (req, res) => {
+  if (!TWITCH_CLIENT_ID || !TWITCH_CLIENT_SECRET || !TWITCH_REDIRECT_URI) {
+    return res.status(500).json({ error: 'OAuth ist nicht vollständig konfiguriert.' });
+  }
+  const scopes = Array.isArray(req.query.scope)
+    ? req.query.scope
+    : (typeof req.query.scope === 'string' ? req.query.scope.split(',').map(s => s.trim()).filter(Boolean) : ['chat:read', 'chat:edit']);
+  const state = crypto.randomBytes(24).toString('hex');
+  oauthStates.set(state, { createdAt: Date.now(), scopes });
+  const params = new URLSearchParams({
+    client_id: TWITCH_CLIENT_ID,
+    redirect_uri: TWITCH_REDIRECT_URI,
+    response_type: 'code',
+    scope: scopes.join(' '),
+    state
+  });
+  res.json({
+    url: `https://id.twitch.tv/oauth2/authorize?${params.toString()}`,
+    state,
+    scopes
+  });
+});
+
+app.get('/api/twitch/oauth/callback', async (req, res) => {
+  const { state, code, error, error_description: errorDescription } = req.query;
+  if (error) {
+    return renderOauthResult(res, { error, errorDescription });
+  }
+  if (!state || !code) {
+    return renderOauthResult(res, { error: 'invalid_request', errorDescription: 'Parameter state oder code fehlt.' });
+  }
+  const entry = oauthStates.get(state);
+  if (!entry) {
+    return renderOauthResult(res, { error: 'invalid_state', errorDescription: 'State ist unbekannt oder abgelaufen.' });
+  }
+  oauthStates.delete(state);
+  if (!TWITCH_CLIENT_ID || !TWITCH_CLIENT_SECRET || !TWITCH_REDIRECT_URI) {
+    return renderOauthResult(res, { error: 'server_error', errorDescription: 'OAuth ist serverseitig nicht vollständig konfiguriert.' });
+  }
+  try {
+    const params = new URLSearchParams({
+      client_id: TWITCH_CLIENT_ID,
+      client_secret: TWITCH_CLIENT_SECRET,
+      code,
+      grant_type: 'authorization_code',
+      redirect_uri: TWITCH_REDIRECT_URI
+    });
+    const tokenResponse = await axios.post('https://id.twitch.tv/oauth2/token', params, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    });
+    return renderOauthResult(res, {
+      accessToken: tokenResponse.data?.access_token,
+      refreshToken: tokenResponse.data?.refresh_token,
+      scope: tokenResponse.data?.scope || entry.scopes,
+      expiresIn: tokenResponse.data?.expires_in
+    });
+  } catch (err) {
+    console.error('[twitch-chat-controller] OAuth-Token konnte nicht geholt werden:', err?.response?.data || err);
+    const errorPayload = err?.response?.data || {};
+    return renderOauthResult(res, {
+      error: errorPayload.error || 'token_error',
+      errorDescription: errorPayload.error_description || err.message
+    });
+  }
+});
+
+function renderOauthResult(res, payload) {
+  const data = JSON.stringify(payload);
+  const html = `<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <title>Twitch OAuth Ergebnis</title>
+    <style>
+      body { font-family: system-ui, sans-serif; background: #0f0f0f; color: #f5f5f5; display: flex; align-items: center; justify-content: center; min-height: 100vh; padding: 2rem; }
+      main { background: rgba(255,255,255,0.05); border-radius: 16px; padding: 2rem; max-width: 480px; width: 100%; box-shadow: 0 20px 60px rgba(0,0,0,0.35); }
+      h1 { margin-top: 0; font-size: 1.5rem; }
+      pre { background: rgba(0,0,0,0.35); padding: 1rem; border-radius: 12px; overflow: auto; font-size: 0.85rem; }
+      button { margin-top: 1.5rem; padding: 0.75rem 1.5rem; border-radius: 999px; border: none; background: #9146ff; color: #fff; font-size: 1rem; cursor: pointer; }
+      button:hover { background: #772ce8; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>OAuth Ergebnis</h1>
+      <p>Das Fenster kann geschlossen werden. Die Daten wurden an die ursprüngliche Seite gesendet.</p>
+      <pre>${data.replace(/</g, '&lt;')}</pre>
+      <button onclick="window.close()">Fenster schließen</button>
+    </main>
+    <script>
+      (function() {
+        const payload = ${data};
+        if (window.opener) {
+          window.opener.postMessage({ type: 'twitch-oauth', payload }, '*');
+        }
+      })();
+    </script>
+  </body>
+</html>`;
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  return res.send(html);
+}
+
+setInterval(() => {
+  const cutoff = Date.now() - 5 * 60 * 1000;
+  for (const [state, entry] of oauthStates.entries()) {
+    if (entry.createdAt < cutoff) {
+      oauthStates.delete(state);
+    }
+  }
+}, 60 * 1000).unref?.();
+
+app.listen(PORT, () => {
+  console.log(`[twitch-chat-controller] Server läuft auf Port ${PORT}`);
+});

--- a/projects/sites/dev/app.js
+++ b/projects/sites/dev/app.js
@@ -65,6 +65,20 @@
           description: 'Errate Anime-Charaktere über das Chat-Interface mit KI-Unterstützung.'
         }
       ]
+    },
+    {
+      type: 'group',
+      id: 'twitch',
+      label: 'Streaming & Twitch',
+      items: [
+        {
+          type: 'page',
+          id: 'twitch-chat',
+          label: 'Twitch Chat Steuerung',
+          url: '../services/twitch-bot/index.html',
+          description: 'Verbinde einen Bot-Account, überwache den Chat und sende Nachrichten direkt aus dem Browser.'
+        }
+      ]
     }
   ];
 

--- a/projects/sites/dev/pages.js
+++ b/projects/sites/dev/pages.js
@@ -3,5 +3,6 @@ const pages = [
   { title: 'Konfiguration (Standalone)', url: './config.html' },
   { title: 'Digital Mode', url: '../services/hitster/gameModeDigital.html' },
   { title: 'Kostenkalkulation', url: '../services/planning/bill-splitter.html' },
-  { title: 'Anime Rätsel Chat', url: '../services/anime/animeCharakterdle.html' }
+  { title: 'Anime Rätsel Chat', url: '../services/anime/animeCharakterdle.html' },
+  { title: 'Twitch Chat Steuerung', url: '../services/twitch-bot/index.html' }
 ];

--- a/projects/sites/dev/services/twitch-bot/README.md
+++ b/projects/sites/dev/services/twitch-bot/README.md
@@ -1,0 +1,19 @@
+# Twitch Chat Steuerung (Frontend)
+
+Dieses Frontend dient als Kontrollzentrale für den Twitch Bot-Service aus `projects/dev-backend/twitch-chat-controller`. Es ermöglicht, ein API-Passwort einzugeben, den gewünschten Kanal zu wählen, Chatnachrichten in Echtzeit einzusehen und über den Bot-Account in den Chat zu schreiben. Zusätzlich kann ein OAuth-Testlauf gestartet werden, der die von Twitch zurückgelieferten Tokens im Browser anzeigt.
+
+## Aufbau
+
+- **Backend-Verbindung**: Eingabefelder für API-Basis-URL und Passwort. Nach erfolgreicher Verbindung werden Statusinformationen angezeigt und weitere Aktionen freigeschaltet.
+- **OAuth-Test**: Startet den Autorisierungs-Flow über `/api/twitch/oauth/authorize`. Der Callback sendet die Tokens via `postMessage` zurück.
+- **Chat-Ansicht**: Baut eine SSE-Verbindung (`/api/twitch/chat/stream`) auf, zeigt eingehende Nachrichten an und erlaubt das Versenden neuer Nachrichten über `/api/twitch/chat/send`.
+
+## Nutzung
+
+1. Backend bereitstellen und sicherstellen, dass es unter der gewünschten Domain via `/api/twitch` erreichbar ist.
+2. Seite unter `https://www.behamot.de/services/twitch-bot/` aufrufen.
+3. API-Basis (`https://www.behamot.de/api/twitch`) und Passwort eingeben, auf „Verbinden“ klicken.
+4. Channel auswählen (z. B. `behamot007`) und den Chat abonnieren.
+5. Optional: OAuth-Test starten, um Benutzer-Tokens für weitere Funktionen zu erhalten.
+
+Die Seite speichert lediglich die API-Basis-URL und den zuletzt verwendeten Channel in `localStorage`. Das Passwort wird aus Sicherheitsgründen nicht persistiert.

--- a/projects/sites/dev/services/twitch-bot/index.html
+++ b/projects/sites/dev/services/twitch-bot/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Twitch Chat Steuerung</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="app-header__brand">
+        <span class="app-header__logo">🛠️</span>
+        <div>
+          <h1>Twitch Chat Steuerung</h1>
+          <p>Bot-Kanal überwachen &amp; Nachrichten versenden</p>
+        </div>
+      </div>
+      <nav class="app-header__nav">
+        <a href="../../index.html">← Zurück zur Übersicht</a>
+      </nav>
+    </header>
+
+    <main class="app-grid">
+      <section class="card">
+        <h2>Backend-Verbindung</h2>
+        <form id="connectionForm" class="form-grid">
+          <label>
+            <span>API-Basis-URL</span>
+            <input id="apiBase" type="url" placeholder="https://www.behamot.de/api/twitch" required />
+          </label>
+          <label>
+            <span>API-Passwort</span>
+            <input id="apiPassword" type="password" autocomplete="current-password" required />
+          </label>
+          <div class="form-actions">
+            <button type="submit">Verbinden</button>
+            <button type="button" id="clearPassword" class="secondary">Passwort löschen</button>
+          </div>
+        </form>
+        <div id="connectionStatus" class="status-box">Nicht verbunden</div>
+      </section>
+
+      <section class="card">
+        <h2>OAuth-Test</h2>
+        <p>
+          Öffnet den Twitch-Login in einem Pop-up. Nach erfolgreicher Anmeldung sendet das Pop-up die Tokens an diese Seite zurück.
+        </p>
+        <div class="oauth-grid">
+          <button id="oauthStart" disabled>OAuth starten</button>
+          <div class="status-box" id="oauthInfo">Noch kein Token angefordert.</div>
+        </div>
+      </section>
+
+      <section class="card card--wide">
+        <div class="card-header">
+          <h2>Chat-Ansicht</h2>
+          <div class="channel-form">
+            <label>
+              <span>Channel</span>
+              <input id="channelInput" type="text" placeholder="beispielkanal" />
+            </label>
+            <button id="connectChannel" disabled>Chat abonnieren</button>
+          </div>
+        </div>
+        <div id="chatLog" class="chat-log" aria-live="polite"></div>
+        <form id="messageForm" class="message-form">
+          <textarea id="messageInput" rows="2" placeholder="Nachricht schreiben..." required></textarea>
+          <button type="submit" disabled>Senden</button>
+        </form>
+      </section>
+    </main>
+
+    <template id="messageTemplate">
+      <article class="chat-message">
+        <div class="chat-message__meta">
+          <span class="chat-message__user"></span>
+          <time class="chat-message__time"></time>
+        </div>
+        <p class="chat-message__text"></p>
+      </article>
+    </template>
+
+    <script type="module" src="./script.js"></script>
+  </body>
+</html>

--- a/projects/sites/dev/services/twitch-bot/script.js
+++ b/projects/sites/dev/services/twitch-bot/script.js
@@ -1,0 +1,339 @@
+const connectionForm = document.getElementById('connectionForm');
+const apiBaseInput = document.getElementById('apiBase');
+const apiPasswordInput = document.getElementById('apiPassword');
+const clearPasswordBtn = document.getElementById('clearPassword');
+const connectionStatusEl = document.getElementById('connectionStatus');
+const oauthButton = document.getElementById('oauthStart');
+const oauthInfoEl = document.getElementById('oauthInfo');
+const channelInput = document.getElementById('channelInput');
+const connectChannelBtn = document.getElementById('connectChannel');
+const chatLog = document.getElementById('chatLog');
+const messageForm = document.getElementById('messageForm');
+const messageInput = document.getElementById('messageInput');
+const messageSubmit = messageForm.querySelector('button');
+const messageTemplate = document.getElementById('messageTemplate');
+
+const STORAGE_KEYS = {
+  apiBase: 'twitch-bot.apiBase',
+  channel: 'twitch-bot.channel'
+};
+
+let apiBase = localStorage.getItem(STORAGE_KEYS.apiBase) || '/api/twitch';
+let apiPassword = '';
+let currentChannel = '';
+let eventSource = null;
+let lastOauthPayload = null;
+let statusData = null;
+
+apiBaseInput.value = apiBase;
+const storedChannel = localStorage.getItem(STORAGE_KEYS.channel);
+if (storedChannel) {
+  channelInput.value = storedChannel;
+}
+
+function trimBase(value) {
+  let result = (value || '').trim().replace(/\/$/, '');
+  if (result && !/^https?:/i.test(result) && !result.startsWith('/')) {
+    result = `/${result}`;
+  }
+  return result;
+}
+
+function buildUrl(path) {
+  const base = trimBase(apiBase || '');
+  if (!base) return path;
+  if (base.startsWith('http')) {
+    return `${base}${path}`;
+  }
+  if (!path.startsWith('/')) {
+    return `${base}/${path}`;
+  }
+  return `${base}${path}`;
+}
+
+async function apiFetch(path, options = {}) {
+  if (!apiPassword) {
+    throw new Error('Kein API-Passwort gesetzt.');
+  }
+  const target = buildUrl(path);
+  const init = { method: options.method || 'GET', headers: new Headers(options.headers || {}) };
+  init.headers.set('Accept', 'application/json');
+  if (!options.skipAuth) {
+    init.headers.set('Authorization', `Bearer ${apiPassword}`);
+  }
+  if (options.body) {
+    if (typeof options.body === 'string') {
+      init.body = options.body;
+    } else {
+      init.body = JSON.stringify(options.body);
+      init.headers.set('Content-Type', 'application/json');
+    }
+  }
+  const response = await fetch(target, init);
+  const contentType = response.headers.get('content-type') || '';
+  const isJson = contentType.includes('application/json');
+  const payload = isJson ? await response.json() : await response.text();
+  if (!response.ok) {
+    const message = payload?.error || payload?.message || response.statusText;
+    throw new Error(message || 'Unbekannter Fehler');
+  }
+  return payload;
+}
+
+function setStatus(text, variant = '') {
+  connectionStatusEl.textContent = text;
+  connectionStatusEl.classList.remove('status-box--ok', 'status-box--error');
+  if (variant === 'ok') {
+    connectionStatusEl.classList.add('status-box--ok');
+  } else if (variant === 'error') {
+    connectionStatusEl.classList.add('status-box--error');
+  }
+}
+
+function setOauthInfo(content, variant = '') {
+  oauthInfoEl.textContent = content;
+  oauthInfoEl.classList.remove('status-box--ok', 'status-box--error');
+  if (variant === 'ok') {
+    oauthInfoEl.classList.add('status-box--ok');
+  } else if (variant === 'error') {
+    oauthInfoEl.classList.add('status-box--error');
+  }
+}
+
+function clearChat() {
+  chatLog.innerHTML = '';
+}
+
+function appendMessage(entry) {
+  if (!entry) return;
+  const { type, username, message, timestamp, channel, userId } = entry;
+  const clone = messageTemplate.content.firstElementChild.cloneNode(true);
+  const article = clone;
+  const userEl = clone.querySelector('.chat-message__user');
+  const timeEl = clone.querySelector('.chat-message__time');
+  const textEl = clone.querySelector('.chat-message__text');
+
+  const date = timestamp ? new Date(timestamp) : new Date();
+  timeEl.textContent = date.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  if (type === 'system') {
+    article.classList.add('chat-message--system');
+    userEl.textContent = '# ' + (channel || currentChannel || 'system');
+    textEl.textContent = message || '';
+  } else if (type === 'outgoing') {
+    article.classList.add('chat-message--bot');
+    userEl.textContent = `BOT · ${username || 'Bot'}`;
+    textEl.textContent = message || '';
+  } else {
+    userEl.textContent = username || userId || 'Unbekannt';
+    textEl.textContent = message || '';
+  }
+
+  chatLog.appendChild(clone);
+  chatLog.scrollTop = chatLog.scrollHeight;
+}
+
+function handleStreamData(event) {
+  try {
+    const payload = JSON.parse(event.data);
+    appendMessage(payload);
+  } catch (error) {
+    console.error('Konnte Stream-Payload nicht parsen', error, event.data);
+  }
+}
+
+function handleStreamError(event) {
+  console.warn('SSE Fehler', event);
+  messageSubmit.disabled = true;
+  connectChannelBtn.disabled = false;
+  connectChannelBtn.textContent = 'Neu verbinden';
+  appendMessage({
+    type: 'system',
+    channel: currentChannel,
+    message: 'Verbindung zum Chat-Stream unterbrochen. Bitte erneut verbinden.',
+    timestamp: new Date().toISOString()
+  });
+}
+
+function closeStream() {
+  if (eventSource) {
+    eventSource.close();
+    eventSource = null;
+  }
+  messageSubmit.disabled = true;
+}
+
+async function connectChannel(channel) {
+  if (!channel) {
+    throw new Error('Kein Channel angegeben.');
+  }
+  closeStream();
+  clearChat();
+  const normalized = channel.replace(/^#/, '').trim().toLowerCase();
+  currentChannel = normalized;
+  localStorage.setItem(STORAGE_KEYS.channel, normalized);
+  connectChannelBtn.disabled = true;
+  connectChannelBtn.textContent = 'Verbinde…';
+  appendMessage({
+    type: 'system',
+    channel: normalized,
+    message: `Verbinde zu #${normalized}...`,
+    timestamp: new Date().toISOString()
+  });
+  const streamUrl = `${trimBase(apiBase)}/chat/stream?channel=${encodeURIComponent(normalized)}&apiPassword=${encodeURIComponent(apiPassword)}`;
+  eventSource = new EventSource(streamUrl);
+  eventSource.onopen = () => {
+    appendMessage({
+      type: 'system',
+      channel: normalized,
+      message: `Chat-Stream aktiv.`,
+      timestamp: new Date().toISOString()
+    });
+    connectChannelBtn.disabled = false;
+    connectChannelBtn.textContent = 'Neu verbinden';
+  };
+  eventSource.onmessage = handleStreamData;
+  eventSource.onerror = handleStreamError;
+  messageSubmit.disabled = false;
+}
+
+async function refreshStatus() {
+  try {
+    statusData = await apiFetch('/status');
+    const parts = [];
+    if (statusData.ready) {
+      parts.push('Bot ist mit Twitch verbunden.');
+    } else {
+      parts.push('Bot-Verbindung wird aufgebaut …');
+    }
+    if (statusData.defaultChannel) {
+      parts.push(`Standardchannel: #${statusData.defaultChannel}`);
+      if (!channelInput.value) {
+        channelInput.value = statusData.defaultChannel;
+      }
+    }
+    setStatus(parts.join(' '), statusData.ready ? 'ok' : '');
+    oauthButton.disabled = !statusData.oauthConfigured;
+    connectChannelBtn.disabled = false;
+    connectChannelBtn.textContent = 'Chat abonnieren';
+  } catch (error) {
+    setStatus(`Fehler: ${error.message}`, 'error');
+    oauthButton.disabled = true;
+    connectChannelBtn.disabled = true;
+    throw error;
+  }
+}
+
+connectionForm.addEventListener('submit', async event => {
+  event.preventDefault();
+  apiBase = trimBase(apiBaseInput.value.trim() || '');
+  apiPassword = apiPasswordInput.value.trim();
+  if (!apiBase || !apiPassword) {
+    setStatus('Bitte Basis-URL und Passwort angeben.', 'error');
+    return;
+  }
+  localStorage.setItem(STORAGE_KEYS.apiBase, apiBase);
+  setStatus('Prüfe Backend …');
+  try {
+    await refreshStatus();
+  } catch (error) {
+    console.error('Verbindungsaufbau fehlgeschlagen', error);
+  }
+});
+
+clearPasswordBtn.addEventListener('click', () => {
+  apiPassword = '';
+  apiPasswordInput.value = '';
+  setStatus('Passwort wurde gelöscht. Bitte neu verbinden.');
+  oauthButton.disabled = true;
+  connectChannelBtn.disabled = true;
+  connectChannelBtn.textContent = 'Chat abonnieren';
+  closeStream();
+  messageSubmit.disabled = true;
+});
+
+connectChannelBtn.addEventListener('click', async () => {
+  if (!apiPassword) {
+    setStatus('Bitte zuerst mit dem Backend verbinden.', 'error');
+    return;
+  }
+  const channel = channelInput.value.trim();
+  if (!channel) {
+    setStatus('Bitte einen Channel eingeben.', 'error');
+    return;
+  }
+  try {
+    await connectChannel(channel);
+    setStatus(`Stream verbunden mit #${currentChannel}.`, 'ok');
+  } catch (error) {
+    setStatus(`Chat konnte nicht verbunden werden: ${error.message}`, 'error');
+    connectChannelBtn.disabled = false;
+    connectChannelBtn.textContent = 'Neu verbinden';
+  }
+});
+
+messageForm.addEventListener('submit', async event => {
+  event.preventDefault();
+  const text = messageInput.value.trim();
+  if (!text) return;
+  if (!currentChannel) {
+    setStatus('Kein Channel verbunden.', 'error');
+    return;
+  }
+  try {
+    await apiFetch('/chat/send', {
+      method: 'POST',
+      body: { channel: currentChannel, message: text }
+    });
+    messageInput.value = '';
+  } catch (error) {
+    setStatus(`Nachricht konnte nicht gesendet werden: ${error.message}`, 'error');
+  }
+});
+
+oauthButton.addEventListener('click', async () => {
+  try {
+    setOauthInfo('Fordere OAuth-URL an …');
+    const result = await apiFetch('/oauth/authorize');
+    const popup = window.open(result.url, 'twitch-oauth', 'width=600,height=800');
+    if (!popup) {
+      setOauthInfo('Popup konnte nicht geöffnet werden. Bitte Pop-up-Blocker deaktivieren.', 'error');
+      return;
+    }
+    setOauthInfo('Bitte Login im Twitch-Popup durchführen …');
+  } catch (error) {
+    setOauthInfo(`Fehler: ${error.message}`, 'error');
+  }
+});
+
+window.addEventListener('message', event => {
+  const data = event.data;
+  if (!data || data.type !== 'twitch-oauth') return;
+  lastOauthPayload = data.payload;
+  if (data.payload?.error) {
+    setOauthInfo(`OAuth-Fehler: ${data.payload.errorDescription || data.payload.error}`, 'error');
+    return;
+  }
+  setOauthInfo(
+    `Token erhalten (läuft in ${data.payload?.expiresIn || '?'}s ab). Scopes: ${(data.payload?.scope || []).join(', ')}`,
+    'ok'
+  );
+  console.log('OAuth Payload', data.payload);
+});
+
+window.addEventListener('beforeunload', () => {
+  closeStream();
+});
+
+setStatus('Bitte verbinde dich mit dem Backend.');
+messageSubmit.disabled = true;
+connectChannelBtn.disabled = true;
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    return;
+  }
+  if (apiPassword && currentChannel && !eventSource) {
+    connectChannelBtn.click();
+  }
+});

--- a/projects/sites/dev/services/twitch-bot/styles.css
+++ b/projects/sites/dev/services/twitch-bot/styles.css
@@ -1,0 +1,279 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top left, #26203b, #101018 55%);
+  color: #f6f6f9;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem clamp(1.5rem, 5vw, 3rem);
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.app-header__brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.app-header__logo {
+  font-size: 2rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.app-header p {
+  margin: 0.25rem 0 0;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.95rem;
+}
+
+.app-header__nav a {
+  color: #d3caff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.app-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem clamp(1.5rem, 5vw, 3rem) 3rem;
+}
+
+.card {
+  background: rgba(16, 16, 24, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 24px 48px rgba(8, 6, 20, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.card--wide {
+  grid-column: 1 / -1;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(145, 70, 255, 0.6);
+  background: rgba(145, 70, 255, 0.08);
+}
+
+button {
+  border-radius: 14px;
+  border: none;
+  padding: 0.85rem 1.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background: linear-gradient(135deg, #7a5cff, #9146ff);
+  color: #fff;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.3s ease;
+  box-shadow: 0 12px 30px rgba(83, 63, 255, 0.35);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(83, 63, 255, 0.45);
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.status-box {
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.status-box--ok {
+  border-color: rgba(46, 204, 113, 0.6);
+  background: rgba(46, 204, 113, 0.08);
+  color: #a5f5c0;
+}
+
+.status-box--error {
+  border-color: rgba(231, 76, 60, 0.6);
+  background: rgba(231, 76, 60, 0.08);
+  color: #ffb3a7;
+}
+
+.oauth-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.channel-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.channel-form label {
+  flex: 1;
+}
+
+.chat-log {
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  min-height: 280px;
+  max-height: 420px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  font-size: 0.95rem;
+}
+
+.chat-message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.chat-message--bot {
+  border-color: rgba(145, 70, 255, 0.5);
+  background: rgba(145, 70, 255, 0.12);
+}
+
+.chat-message--system {
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.chat-message__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.chat-message__user {
+  font-weight: 700;
+}
+
+.chat-message__time {
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-message__text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.message-form {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.message-form textarea {
+  flex: 1;
+  resize: vertical;
+}
+
+@media (max-width: 900px) {
+  .card-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .channel-form {
+    width: 100%;
+  }
+
+  .message-form {
+    flex-direction: column;
+  }
+
+  .message-form button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated twitch-chat-controller express service with secured API endpoints, SSE chat streaming and OAuth helper
- build a matching control panel in projects/sites/dev/services/twitch-bot with password gate, chat view and OAuth test workflow
- wire the new service into docker compose, nginx proxy rules, env templates and documentation

## Testing
- npm install *(fails: npm registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e004d14f00832f9206b0d534f07175