### PR TITLE
Fix dev toolkit navigation links

### DIFF
--- a/projects/sites/dev/app.js
+++ b/projects/sites/dev/app.js
@@ -33,7 +33,7 @@
           type: 'page',
           id: 'digital-mode',
           label: 'Digital Mode',
-          url: '../services/hitster/gameModeDigital.html',
+          url: './services/hitster/gameModeDigital.html',
           description: 'Vollständig digitales Hitster-Brettspiel mit Spotify-Steuerung und KI-Hilfen.'
         }
       ]
@@ -47,7 +47,7 @@
           type: 'page',
           id: 'bill-splitter',
           label: 'Kostenkalkulation',
-          url: '../services/planning/bill-splitter.html',
+          url: './services/planning/bill-splitter.html',
           description: 'Berechne faire Anteile für gemeinsame Rechnungen und Freunde.'
         }
       ]
@@ -61,7 +61,7 @@
           type: 'page',
           id: 'anime-riddle',
           label: 'Rätsel Chat',
-          url: '../services/anime/animeCharakterdle.html',
+          url: './services/anime/animeCharakterdle.html',
           description: 'Errate Anime-Charaktere über das Chat-Interface mit KI-Unterstützung.'
         }
       ]
@@ -75,7 +75,7 @@
           type: 'page',
           id: 'twitch-chat',
           label: 'Twitch Chat Steuerung',
-          url: '../services/twitch-bot/index.html',
+          url: './services/twitch-bot/index.html',
           description: 'Verbinde einen Bot-Account, überwache den Chat und sende Nachrichten direkt aus dem Browser.'
         }
       ]

--- a/projects/sites/dev/pages.js
+++ b/projects/sites/dev/pages.js
@@ -1,8 +1,8 @@
 const pages = [
   { title: 'Home', url: './index.html' },
   { title: 'Konfiguration (Standalone)', url: './config.html' },
-  { title: 'Digital Mode', url: '../services/hitster/gameModeDigital.html' },
-  { title: 'Kostenkalkulation', url: '../services/planning/bill-splitter.html' },
-  { title: 'Anime Rätsel Chat', url: '../services/anime/animeCharakterdle.html' },
-  { title: 'Twitch Chat Steuerung', url: '../services/twitch-bot/index.html' }
+  { title: 'Digital Mode', url: './services/hitster/gameModeDigital.html' },
+  { title: 'Kostenkalkulation', url: './services/planning/bill-splitter.html' },
+  { title: 'Anime Rätsel Chat', url: './services/anime/animeCharakterdle.html' },
+  { title: 'Twitch Chat Steuerung', url: './services/twitch-bot/index.html' }
 ];


### PR DESCRIPTION
## Summary
- correct the dev toolkit navigation to use relative links into the local services folder so the pages stop redirecting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00d63979c832f8861e88d4bec2e50