### PR TITLE
Add Twitch controller proxy to nginx template

### DIFF
--- a/docker/nginx/templates/dev_www.conf.tpl
+++ b/docker/nginx/templates/dev_www.conf.tpl
@@ -17,6 +17,15 @@ server {
         try_files $uri =404;
     }
 
+    location /api/twitch/ {
+        proxy_pass http://twitch-controller:4010;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api/ {
         proxy_pass http://backend:3000;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- add a dedicated /api/twitch location to the nginx template so Twitch bot requests are forwarded to the controller service

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e018ac9d7c832fb191f7ead4805d98