### PR TITLE
Show Twitch bot self messages in chat stream

### DIFF
--- a/projects/sites/dev/services/twitch-bot/script.js
+++ b/projects/sites/dev/services/twitch-bot/script.js
@@ -120,6 +120,10 @@ function appendMessage(entry) {
     article.classList.add('chat-message--system');
     userEl.textContent = '# ' + (channel || currentChannel || 'system');
     textEl.textContent = message || '';
+  } else if (type === 'self') {
+    article.classList.add('chat-message--self');
+    userEl.textContent = `${username || userId || 'Du'} · Eigene Nachricht`;
+    textEl.textContent = message || '';
   } else if (type === 'outgoing') {
     article.classList.add('chat-message--bot');
     userEl.textContent = `BOT · ${username || 'Bot'}`;

--- a/projects/sites/dev/services/twitch-bot/styles.css
+++ b/projects/sites/dev/services/twitch-bot/styles.css
@@ -221,6 +221,11 @@ button.secondary {
   background: rgba(145, 70, 255, 0.12);
 }
 
+.chat-message--self {
+  border-color: rgba(46, 204, 113, 0.45);
+  background: rgba(46, 204, 113, 0.12);
+}
+
 .chat-message--system {
   font-style: italic;
   color: rgba(255, 255, 255, 0.7);


### PR DESCRIPTION
## Summary
- track pending bot messages in the chat controller so self-authored messages are not dropped but duplicates are prevented
- expose self-authored chat events to the frontend and add a dedicated visual style for them

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e038e07090832fb6024f6d513094d1