### PR TITLE
Add advanced Twitch command management and automation

### DIFF
--- a/projects/dev-backend/twitch-chat-controller/README.md
+++ b/projects/dev-backend/twitch-chat-controller/README.md
@@ -107,6 +107,22 @@ Alle Routen (bis auf den OAuth-Callback) verlangen das korrekte Passwort, entwed
 | `GET` | `/api/twitch/commands` | Liefert das aktuelle Befehlspräfix sowie alle konfigurierten Kommandos. |
 | `PUT` | `/api/twitch/commands` | Überschreibt Präfix und Befehle. |
 
+### Kommando-Konfiguration
+
+Die Befehlsverwaltung arbeitet mit einer Liste aus Objekten unterhalb des Schlüssels `items`. Jedes Kommando besitzt folgende Felder:
+
+| Feld | Typ | Beschreibung |
+|------|-----|--------------|
+| `names` | `string[]` | Liste aller Alias-Namen ohne Präfix. Mehrere Namen verweisen auf denselben Befehl und teilen sich Cooldown & Rechte. |
+| `response` | `string` | Nachricht, die der Bot sendet. Platzhalter wie `{user}`, `{channel}` oder `{message}` werden automatisch ersetzt. |
+| `cooldownSeconds` | `number` | Mindestabstand in Sekunden zwischen manuellen Ausführungen. |
+| `autoIntervalSeconds` | `number` | Optionales Intervall für automatische Ausführung. Der Bot sendet die Antwort in alle verbundenen Channels. |
+| `minUserLevel` | `"everyone"\|"subscriber"\|"regular"\|"vip"\|"moderator"\|"super-moderator"\|"broadcaster"` | Erforderliche Twitch-Benutzerstufe. Nutzer unterhalb der Stufe erhalten einen Whisper-Hinweis und die auslösende Nachricht wird (sofern erlaubt) gelöscht. |
+| `responseType` | `"say"\|"mention"\|"reply"\|"whisper"` | Legt fest, wie der Bot antwortet (klassische Chat-Nachricht, Erwähnung, Antwort-Thread oder Whisper). Whisper wird bei fehlenden Berechtigungen automatisch zu einer Chat-Nachricht degradiert. |
+| `enabled` | `boolean` | Steuert, ob das Kommando ausgelöst werden kann und ob automatische Intervalle aktiv sind. |
+
+Wird ein Eintrag deaktiviert oder die Rechteprüfung fehlschlägt, sendet der Bot keine Chat-Nachricht und informiert den Nutzer per Whisper über die fehlende Berechtigung. Der Chat-Bot versucht zusätzlich, die ursprüngliche Chat-Nachricht zu entfernen (`channel:moderate`-Scope erforderlich).
+
 ## Frontend-Integration
 
 Die zugehörige Weboberfläche liegt unter `projects/sites/dev/services/twitch-bot`. Sie fragt das Passwort ab, öffnet bei Bedarf den OAuth-Login, übergibt neue Tokens automatisch an das Backend und verbindet sich anschließend via SSE mit dem gewünschten Kanal. Nachrichten können direkt aus dem Browser gesendet werden und erscheinen inklusive Bot-Markierung im Verlauf. Außerdem lassen sich dort Befehlspräfix und Chat-Kommandos konfigurieren.

--- a/projects/sites/dev/services/twitch-bot/README.md
+++ b/projects/sites/dev/services/twitch-bot/README.md
@@ -6,7 +6,7 @@ Dieses Frontend dient als Kontrollzentrale für den Twitch Bot-Service aus `proj
 
 - **Konfiguration**: Formular für das API-Passwort (mit Passwortmanager-Kompatibilität), Anzeige des aktuellen Bot-Token-Status sowie Start des OAuth-Flows. Erfolgreiche Logins werden automatisch an das Backend übermittelt und dort gespeichert/erneuert.
 - **Chat-Ansicht**: Baut eine SSE-Verbindung (`/api/twitch/chat/stream`) auf, zeigt eingehende Nachrichten an (inkl. Bot-Antworten) und erlaubt das Versenden neuer Nachrichten über `/api/twitch/chat/send`.
-- **Befehle**: Oberfläche zum Pflegen des Befehlspräfixes sowie beliebig vieler Chat-Kommandos. Die Konfiguration wird über `/api/twitch/commands` geladen und gespeichert.
+- **Befehle**: Oberfläche zum Pflegen des Befehlspräfixes sowie beliebig vieler Chat-Kommandos inklusive Alias-Verwaltung, Benutzerstufen, Antworttypen und optionalen Automatik-Intervallen. Die Konfiguration wird über `/api/twitch/commands` geladen und gespeichert.
 
 ## Nutzung
 

--- a/projects/sites/dev/services/twitch-bot/index.html
+++ b/projects/sites/dev/services/twitch-bot/index.html
@@ -118,8 +118,8 @@
               <div>
                 <h2>Befehlsverwaltung</h2>
                 <p class="card__hint">
-                  Lege einen Präfix und individuelle Antworten fest. Platzhalter wie <code>{user}</code> oder
-                  <code>{channel}</code> werden automatisch ersetzt.
+                  Verwalte Präfix, Aliase, automatische Ausführungen und Antworten. Platzhalter wie
+                  <code>{user}</code> oder <code>{channel}</code> werden automatisch ersetzt.
                 </p>
               </div>
               <div class="command-prefix">
@@ -139,6 +139,72 @@
         </div>
       </section>
     </main>
+
+    <div id="commandModal" class="modal" hidden>
+      <div class="modal__content" role="dialog" aria-modal="true" aria-labelledby="commandModalTitle">
+        <header class="modal__header">
+          <h3 id="commandModalTitle">Befehl bearbeiten</h3>
+          <button type="button" class="icon-button" data-command-modal-close aria-label="Schließen">×</button>
+        </header>
+        <form id="commandForm" class="modal__form">
+          <div class="modal__body">
+            <label class="switch" for="commandEnabled">
+              <input type="checkbox" id="commandEnabled" />
+              <span>Aktiver Befehl</span>
+            </label>
+
+            <div class="field">
+              <div class="field__label">Befehlsnamen</div>
+              <p class="field__hint">Mehrere Aliase möglich. Der Präfix wird automatisch ergänzt.</p>
+              <div id="commandNames" class="tag-list" role="list"></div>
+              <div class="field__row">
+                <input
+                  type="text"
+                  id="commandNameInput"
+                  placeholder="Neuer Befehlsname"
+                  autocomplete="off"
+                />
+                <button type="button" class="secondary" id="commandNameAdd">Hinzufügen</button>
+              </div>
+            </div>
+
+            <label class="field" for="commandResponse">
+              <span class="field__label">Antwort</span>
+              <textarea id="commandResponse" rows="4" required></textarea>
+            </label>
+
+            <div class="field field--split">
+              <label for="commandCooldown">
+                <span class="field__label">Cooldown (Sek.)</span>
+                <input type="number" id="commandCooldown" min="0" step="1" />
+              </label>
+              <label for="commandAutoInterval">
+                <span class="field__label">Automatik (Sek.)</span>
+                <input type="number" id="commandAutoInterval" min="0" step="1" />
+              </label>
+            </div>
+
+            <label class="field" for="commandUserLevel">
+              <span class="field__label">Benutzerstufe</span>
+              <select id="commandUserLevel"></select>
+            </label>
+
+            <label class="field" for="commandResponseType">
+              <span class="field__label">Antworttyp</span>
+              <select id="commandResponseType"></select>
+            </label>
+
+            <p id="commandModalError" class="modal__error" hidden></p>
+          </div>
+          <footer class="modal__footer">
+            <button type="button" class="danger" id="commandDelete">Befehl löschen</button>
+            <span class="modal__spacer"></span>
+            <button type="button" class="secondary" data-command-modal-cancel>Abbrechen</button>
+            <button type="submit">Speichern</button>
+          </footer>
+        </form>
+      </div>
+    </div>
 
     <template id="messageTemplate">
       <article class="chat-message">

--- a/projects/sites/dev/services/twitch-bot/styles.css
+++ b/projects/sites/dev/services/twitch-bot/styles.css
@@ -231,72 +231,79 @@ button.secondary {
 }
 
 .command-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.command-item {
+.command-card {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 16px;
-  padding: 1.25rem;
   background: rgba(0, 0, 0, 0.25);
+  padding: 1.1rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.65rem;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: none;
 }
 
-.command-item__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
+.command-card:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(145, 70, 255, 0.45);
+  box-shadow: 0 16px 40px rgba(83, 63, 255, 0.35);
+  background: rgba(145, 70, 255, 0.1);
 }
 
-.command-item__header h3 {
+.command-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+  box-shadow: none;
+}
+
+.command-card--inactive {
+  opacity: 0.55;
+  border-color: rgba(255, 255, 255, 0.04);
+}
+
+.command-card__title {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
+  font-weight: 600;
 }
 
-.command-item__toggle {
+.command-card__aliases {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.command-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.command-card__badge {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(145, 70, 255, 0.12);
   color: rgba(255, 255, 255, 0.75);
 }
 
-.command-item__toggle input {
-  width: 1.1rem;
-  height: 1.1rem;
-}
-
-.command-item__tag {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: rgba(255, 255, 255, 0.55);
-}
-
-.command-item__meta {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.command-item__meta label {
-  flex: 1 1 160px;
-}
-
-.command-item__meta textarea {
-  min-height: 72px;
-  resize: vertical;
-}
-
-.command-item__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.75rem;
+.command-card__badge--muted {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .command-actions {
@@ -305,6 +312,190 @@ button.secondary {
   flex-wrap: wrap;
   gap: 0.75rem;
   margin-top: 0.5rem;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 6, 16, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 1000;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal__content {
+  background: rgba(16, 16, 24, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  width: min(520px, 100%);
+  max-height: 90vh;
+  box-shadow: 0 30px 80px rgba(8, 6, 20, 0.65);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal__form {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.modal__header,
+.modal__footer {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.modal__header {
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.modal__body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+}
+
+.modal__footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.modal__spacer {
+  flex: 1;
+}
+
+.modal__error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #ffb3a7;
+}
+
+.modal-open {
+  overflow: hidden;
+}
+
+.icon-button {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 1.5rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.icon-button:hover {
+  color: #fff;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.switch input {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field__label {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+}
+
+.field__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.field__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.field__row input {
+  flex: 1 1 180px;
+}
+
+.field--split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-height: 2rem;
+}
+
+.tag-list:empty::after {
+  content: 'Noch keine Aliase';
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(145, 70, 255, 0.18);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.tag button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  box-shadow: none;
+}
+
+.tag button:hover {
+  color: #ffb3a7;
+}
+
+button.danger {
+  background: rgba(231, 76, 60, 0.18);
+  color: #ffb3a7;
+  box-shadow: none;
+}
+
+button.danger:hover:not(:disabled) {
+  background: rgba(231, 76, 60, 0.28);
+  box-shadow: none;
 }
 
 .channel-form {
@@ -378,9 +569,13 @@ button.secondary {
   white-space: pre-wrap;
 }
 
-.chat-message .command-item__tag {
+.command-meta {
   display: inline-block;
-  margin-top: 0.25rem;
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 .message-form {
@@ -412,12 +607,7 @@ button.secondary {
     width: 100%;
   }
 
-  .command-item__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .command-item__actions {
-    justify-content: flex-start;
+  .command-list {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- extend the Twitch command backend to support aliases, response types, user level gating, and scheduled automation, including permission enforcement and documentation updates
- redesign the frontend command manager with modal-based editing, alias chips, automation intervals, and user level/response type selectors
- surface command metadata in the chat log and refresh styling to match the new workflow

## Testing
- `node --check projects/sites/dev/services/twitch-bot/script.js`
- `node --check projects/dev-backend/twitch-chat-controller/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68e1143abc78832fad40dbaf6821c967