### PR TITLE
Add OpenAI viewer automation to Twitch bot

### DIFF
--- a/projects/sites/dev/app.js
+++ b/projects/sites/dev/app.js
@@ -77,6 +77,14 @@
           label: 'Twitch Chat Steuerung',
           url: './services/twitch-bot/index.html',
           description: 'Verbinde einen Bot-Account, überwache den Chat und sende Nachrichten direkt aus dem Browser.'
+        },
+        {
+          type: 'page',
+          id: 'twitch-openai-viewer',
+          label: 'OpenAI Zuschauer',
+          url: './services/twitch-bot/index.html#openai',
+          description:
+            'Konfiguriere den automatisierten OpenAI-Zuschauer mit Screenshot-Intervall, Prompt & Ziel-Channel.'
         }
       ]
     }

--- a/projects/sites/dev/services/twitch-bot/README.md
+++ b/projects/sites/dev/services/twitch-bot/README.md
@@ -8,6 +8,7 @@ Dieses Frontend dient als Kontrollzentrale für den Twitch Bot-Service aus `proj
 - **Chat-Ansicht**: Baut eine SSE-Verbindung (`/api/twitch/chat/stream`) auf, zeigt eingehende Nachrichten an (inkl. Bot-Antworten) und erlaubt das Versenden neuer Nachrichten über `/api/twitch/chat/send`.
 - **Befehle**: Oberfläche zum Pflegen des Befehlspräfixes sowie beliebig vieler Chat-Kommandos inklusive Alias-Verwaltung, Benutzerstufen, Antworttypen und optionalen Automatik-Intervallen. Die Konfiguration wird über `/api/twitch/commands` geladen und gespeichert.
 - **Währung**: Tab zur Verwaltung eines kanalweiten Punktesystems. Hier lässt sich der Name der Währung festlegen, ebenso wie die Vergaberate (X Punkte pro Y Minuten aktiver Zuschauer). Der Statusbereich zeigt an, wie viele Konten existieren und welcher Gesamtsaldo aktuell gespeichert ist. Änderungen werden über `/api/twitch/currency` persistiert; Erfolg oder Fehler werden zusätzlich in der Browser-Konsole protokolliert.
+- **OpenAI Zuschauer**: Steuert die automatische KI-Interaktion. Hier lassen sich System-Prompt, Screenshot-Intervall und Ziel-Channel festlegen; Status und letzte Antwort kommen aus `/api/twitch/openai`.
 
 ## Nutzung
 
@@ -18,5 +19,6 @@ Dieses Frontend dient als Kontrollzentrale für den Twitch Bot-Service aus `proj
 5. Channel auswählen (z. B. `behamot007`) und den Chat abonnieren.
 6. Währungssystem konfigurieren (Name, Vergaberate) und speichern, um das Punktesystem zu aktivieren. Anschließend können Befehle optional Kosten definieren, die automatisch vom Nutzerkonto abgebucht werden.
 7. Befehle anpassen und speichern, damit der Bot auf Chat-Kommandos reagieren kann.
+8. Optional: Im Tab „OpenAI Zuschauer“ Automatik aktivieren, Prompt anpassen und das Intervall festlegen. Der Bot sendet dann in den Standard- oder angegebenen Channel periodisch KI-generierte Nachrichten.
 
 Die Seite speichert lediglich den zuletzt verwendeten Channel in `localStorage`. Das Passwort wird aus Sicherheitsgründen nicht persistiert.

--- a/projects/sites/dev/services/twitch-bot/index.html
+++ b/projects/sites/dev/services/twitch-bot/index.html
@@ -34,6 +34,9 @@
         <button type="button" class="page-nav__link" data-target="currency" id="nav-currency">
           Währung
         </button>
+        <button type="button" class="page-nav__link" data-target="openai" id="nav-openai">
+          OpenAI Zuschauer
+        </button>
       </nav>
 
       <section class="page-section is-active" id="view-config" aria-labelledby="nav-config">
@@ -188,6 +191,82 @@
               <div class="currency-summary__item">
                 <span class="currency-summary__label">Vergaberate</span>
                 <span class="currency-summary__value" id="currencySummaryRate">—</span>
+              </div>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="page-section" id="view-openai" aria-labelledby="nav-openai">
+        <div class="cards-grid">
+          <article class="card card--wide">
+            <div class="card-header">
+              <div>
+                <h2>OpenAI Zuschauer</h2>
+                <p class="card__hint">
+                  Automatisch generierte Chat-Nachrichten basierend auf Screenshots des Livestreams und dem aktuellen Chat-Verlauf.
+                </p>
+              </div>
+              <label class="switch" for="openAiEnabled">
+                <input type="checkbox" id="openAiEnabled" />
+                <span>Automatik aktiv</span>
+              </label>
+            </div>
+
+            <form id="openAiForm" class="form-grid" autocomplete="off">
+              <label>
+                <span>Channel (optional)</span>
+                <input id="openAiChannel" type="text" placeholder="Standardchannel verwenden" autocomplete="off" />
+                <p class="field__hint">Leer lassen, um den Default-Channel aus der .env zu nutzen.</p>
+              </label>
+
+              <div class="field field--split">
+                <label for="openAiInterval">
+                  <span class="field__label">Intervall (Sekunden)</span>
+                  <input id="openAiInterval" type="number" min="30" step="5" required />
+                </label>
+                <div class="field">
+                  <span class="field__label">Aktionen</span>
+                  <div class="form-actions">
+                    <button type="submit" id="openAiSave">Konfiguration speichern</button>
+                    <button type="button" id="openAiResetPrompt" class="secondary">Prompt zurücksetzen</button>
+                  </div>
+                </div>
+              </div>
+
+              <label class="field" for="openAiPrompt">
+                <span class="field__label">System-Prompt</span>
+                <textarea id="openAiPrompt" rows="6" required></textarea>
+                <p class="field__hint">Wird als Systemnachricht bei jeder Anfrage an OpenAI verwendet.</p>
+              </label>
+            </form>
+
+            <div id="openAiStatus" class="status-box">Bitte zuerst mit dem Backend verbinden.</div>
+
+            <div id="openAiSummary" class="openai-summary" hidden>
+              <div class="openai-summary__grid">
+                <div class="openai-summary__item">
+                  <span class="openai-summary__label">Ziel-Channel</span>
+                  <span class="openai-summary__value" id="openAiSummaryChannel">—</span>
+                </div>
+                <div class="openai-summary__item">
+                  <span class="openai-summary__label">Intervall</span>
+                  <span class="openai-summary__value" id="openAiSummaryInterval">—</span>
+                </div>
+                <div class="openai-summary__item">
+                  <span class="openai-summary__label">Nächster Lauf</span>
+                  <span class="openai-summary__value" id="openAiSummaryNextRun">—</span>
+                </div>
+                <div class="openai-summary__item">
+                  <span class="openai-summary__label">Letzter Erfolg</span>
+                  <span class="openai-summary__value" id="openAiSummaryLastSuccess">—</span>
+                </div>
+              </div>
+
+              <div class="openai-summary__details">
+                <p><strong>Letzte Nachricht:</strong> <span id="openAiSummaryMessage">—</span></p>
+                <p><strong>Tokenverbrauch:</strong> <span id="openAiSummaryTokens">—</span></p>
+                <p class="openai-summary__error" id="openAiSummaryError" hidden></p>
               </div>
             </div>
           </article>

--- a/projects/sites/dev/services/twitch-bot/styles.css
+++ b/projects/sites/dev/services/twitch-bot/styles.css
@@ -141,7 +141,7 @@ body {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.currency-summary {
+.currency-summary { 
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -171,6 +171,62 @@ body {
 
 .currency-summary__value {
   font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.openai-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.openai-summary[hidden] {
+  display: none;
+}
+
+.openai-summary__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.openai-summary__item {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.openai-summary__label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.openai-summary__value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.openai-summary__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.openai-summary__details p {
+  margin: 0;
+}
+
+.openai-summary__error {
+  color: #ffb3a7;
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- add an automatic OpenAI viewer service on the backend with configurable prompt, interval, and channel
- expose new `/api/twitch/openai` endpoints and persist companion settings including screenshot status updates
- extend the Twitch bot frontend with an OpenAI tab, configuration form, and runtime summary plus updated documentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1215df4b8832facb4cd7652a39894