### PR TITLE
Add Twitch OpenAI history persistence and debug panel

### DIFF
--- a/projects/sites/dev/services/twitch-bot/index.html
+++ b/projects/sites/dev/services/twitch-bot/index.html
@@ -261,6 +261,10 @@
                   <span class="openai-summary__label">Letzter Erfolg</span>
                   <span class="openai-summary__value" id="openAiSummaryLastSuccess">—</span>
                 </div>
+                <div class="openai-summary__item">
+                  <span class="openai-summary__label">Stream-Status</span>
+                  <span class="openai-summary__value" id="openAiSummaryStreamStatus">—</span>
+                </div>
               </div>
 
               <div class="openai-summary__details">
@@ -269,6 +273,34 @@
                 <p class="openai-summary__error" id="openAiSummaryError" hidden></p>
               </div>
             </div>
+
+            <details class="openai-debug" id="openAiDebugPanel" hidden>
+              <summary class="openai-debug__summary">Debug-Details anzeigen</summary>
+              <div class="openai-debug__content">
+                <div class="openai-debug__latest">
+                  <h3>Letzte Ausführung</h3>
+                  <p class="openai-debug__meta" id="openAiDebugMeta">Keine Daten verfügbar.</p>
+                  <div class="openai-debug__screenshot" id="openAiDebugScreenshotWrapper" hidden>
+                    <img id="openAiDebugScreenshot" alt="Letzter verwendeter Screenshot" />
+                  </div>
+                  <div class="openai-debug__payloads">
+                    <div class="openai-debug__payload">
+                      <h4>API Anfrage</h4>
+                      <pre id="openAiDebugRequest" class="openai-debug__pre"></pre>
+                    </div>
+                    <div class="openai-debug__payload">
+                      <h4>API Antwort</h4>
+                      <pre id="openAiDebugResponse" class="openai-debug__pre"></pre>
+                    </div>
+                  </div>
+                </div>
+                <div class="openai-debug__history">
+                  <h3>Historie</h3>
+                  <p id="openAiDebugEmpty" class="openai-debug__empty" hidden>Keine Einträge vorhanden.</p>
+                  <ol id="openAiDebugHistory" class="openai-debug__history-list"></ol>
+                </div>
+              </div>
+            </details>
           </article>
         </div>
       </section>

--- a/projects/sites/dev/services/twitch-bot/styles.css
+++ b/projects/sites/dev/services/twitch-bot/styles.css
@@ -230,6 +230,146 @@ body {
   font-weight: 600;
 }
 
+.openai-debug {
+  margin-top: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+
+.openai-debug[hidden] {
+  display: none;
+}
+
+.openai-debug__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: pointer;
+  padding: 0.85rem 1.25rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.openai-debug__summary::-webkit-details-marker {
+  display: none;
+}
+
+.openai-debug__summary::after {
+  content: '▾';
+  font-size: 0.85rem;
+  opacity: 0.7;
+  transition: transform 0.2s ease;
+}
+
+.openai-debug[open] .openai-debug__summary::after {
+  transform: rotate(180deg);
+}
+
+.openai-debug__content {
+  padding: 1.25rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.openai-debug__latest,
+.openai-debug__history {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.openai-debug__meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.openai-debug__screenshot {
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.openai-debug__screenshot img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.openai-debug__payloads {
+  display: grid;
+  gap: 1rem;
+}
+
+.openai-debug__payload h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.openai-debug__pre {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.4);
+  max-height: 240px;
+  overflow: auto;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.openai-debug__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.openai-debug__history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.openai-debug__history-item {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.openai-debug__history-item time {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.5);
+  margin-bottom: 0.35rem;
+}
+
+.openai-debug__history-item p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.openai-debug__history-meta {
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
 .command-prefix label {
   width: 160px;
 }


### PR DESCRIPTION
## Summary
- persist the OpenAI viewer execution history including screenshots and request/response payloads
- gate OpenAI automation on live stream availability and refresh the captured screenshot each cycle
- expose a collapsible frontend debug panel showing the latest run details and stored history entries

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e12d5ce600832f8ceea76068a17501